### PR TITLE
Fix: Retry integration when node is back online

### DIFF
--- a/custom_components/proxmoxve/__init__.py
+++ b/custom_components/proxmoxve/__init__.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from proxmoxer import ProxmoxAPI, AuthenticationError
 from proxmoxer.core import ResourceException
-from requests.exceptions import ConnectTimeout, SSLError
+from requests.exceptions import ConnectTimeout, SSLError, RetryError, ConnectionError
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
@@ -200,6 +200,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     except ConnectTimeout as error:
         raise ConfigEntryNotReady(
             f"Connection to host {host} timed out during setup"
+        ) from error
+    except RetryError as error:
+        raise ConfigEntryNotReady(
+            f"Connection is unreachable to host {host}"
+        ) from error
+    except ConnectionError as error:
+        raise ConfigEntryNotReady(
+            f"Connection is unreachable to host {host}"
         ) from error
     except ResourceException as error:
         raise ConfigEntryNotReady from error


### PR DESCRIPTION
The fix should result in :

![image](https://user-images.githubusercontent.com/5690163/219866099-619738d7-0875-4dfd-b540-212b0c670bc6.png)

Meanwhile the sensors data are Unavailable:
![image](https://user-images.githubusercontent.com/5690163/219866148-cf7ac1d6-21ce-4636-8d72-a02d3c51d75f.png)

But after node is ready you get:

![image](https://user-images.githubusercontent.com/5690163/219866297-2e7e2e0b-c449-4299-9661-56a981dfd2b6.png)

Fixes #41