### PR TITLE
Fix status paused

### DIFF
--- a/custom_components/proxmoxve/sensor.py
+++ b/custom_components/proxmoxve/sensor.py
@@ -309,6 +309,13 @@ PROXMOX_SENSOR_QEMU: Final[tuple[ProxmoxSensorEntityDescription, ...]] = (
         icon="mdi:server",
         translation_key="node",
     ),
+    ProxmoxSensorEntityDescription(
+        key="status_raw",
+        name="Status",
+        icon="mdi:server",
+        translation_key="status_raw",
+        value_fn=lambda x: "paused" if x.health == "paused" else x.status,
+    ),
     *PROXMOX_SENSOR_CPU,
     *PROXMOX_SENSOR_DISK,
     *PROXMOX_SENSOR_MEMORY,

--- a/custom_components/proxmoxve/strings.json
+++ b/custom_components/proxmoxve/strings.json
@@ -219,6 +219,14 @@
       "node": {
         "name": "Node"
       },
+      "status_raw": {
+        "name": "Status",
+        "state": {
+          "paused": "Paused",
+          "stopped": "Stopped",
+          "running": "Running"
+        }
+      },
       "swap_free": {
         "name": "Swap free"
       },

--- a/custom_components/proxmoxve/translations/en.json
+++ b/custom_components/proxmoxve/translations/en.json
@@ -219,6 +219,14 @@
         "node": {
           "name": "Node"
         },
+        "status_raw": {
+          "name": "Status",
+          "state": {
+            "paused": "Paused",
+            "stopped": "Stopped",
+            "running": "Running"
+          }
+        },
         "swap_free": {
           "name": "Swap free"
         },

--- a/custom_components/proxmoxve/translations/pt-BR.json
+++ b/custom_components/proxmoxve/translations/pt-BR.json
@@ -135,6 +135,14 @@
           "node": {
               "name": "Nó"
           },
+          "status_raw": {
+            "name": "Status",
+            "state": {
+              "paused": "Pausado",
+              "stopped": "Desligado",
+              "running": "Executando"
+            }
+          },
           "swap_free": {
             "name": "Swap disponível"
           },


### PR DESCRIPTION
Fixes #137

The status binary sensor represents whether the VM/CT is running and for the Proxmox API the paused status is running.

To inform the paused status, a new status sensor was included that will represent the state of the VM/CT (Running, Stopped, Paused or another state not handled by the integration).