### PR TITLE
Add physical disk information

### DIFF
--- a/custom_components/proxmoxve/const.py
+++ b/custom_components/proxmoxve/const.py
@@ -45,6 +45,7 @@ class ProxmoxType(StrEnum):
     LXC = "lxc"
     Storage = "storage"
     Update = "update"
+    Disk = "disk"
 
 
 class ProxmoxCommand(StrEnum):

--- a/custom_components/proxmoxve/models.py
+++ b/custom_components/proxmoxve/models.py
@@ -128,3 +128,19 @@ class ProxmoxUpdateData:
     updates_list: list
     total: float
     update: bool
+
+
+@dataclasses.dataclass
+class ProxmoxDiskData:
+    """Data parsed from the Proxmox API for Disks."""
+
+    type: str
+    node: str
+    size: float
+    health: str
+    serial: str
+    model: str
+    vendor: str
+    path: str
+    disk_rpm: float
+    disk_type: str

--- a/custom_components/proxmoxve/strings.json
+++ b/custom_components/proxmoxve/strings.json
@@ -190,6 +190,12 @@
       "disk_free_perc": {
         "name": "Disk free percentage"
       },
+      "disk_rpm": {
+        "name": "Disk speed"
+      },
+      "disk_size": {
+        "name": "Size"
+      },
       "disk_total": {
         "name": "Disk total"
       },

--- a/custom_components/proxmoxve/translations/en.json
+++ b/custom_components/proxmoxve/translations/en.json
@@ -190,6 +190,12 @@
         "disk_free_perc": {
           "name": "Disk free percentage"
         },
+        "disk_rpm": {
+          "name": "Disk speed"
+        },
+        "disk_size": {
+          "name": "Size"
+        },
         "disk_total": {
           "name": "Disk total"
         },

--- a/custom_components/proxmoxve/translations/pt-BR.json
+++ b/custom_components/proxmoxve/translations/pt-BR.json
@@ -102,6 +102,12 @@
           "disk_free_perc": {
             "name": "Disco percentual disponível"
           },
+          "disk_rpm": {
+            "name": "Velocidade do disco"
+          },
+          "disk_size": {
+            "name": "Tamanho"
+          },
           "disk_total": {
             "name": "Disco total"
           },


### PR DESCRIPTION
Adds the physical disks as devices and the disk size and health entities.

![image](https://github.com/dougiteixeira/proxmoxve/assets/31328123/036e2060-cd71-486b-b2b7-33835baae10b)

Also added is the disk speed entity, which is disabled by default.
This entity will only work for hard drives (for SSD drives the status will be unknown).