### PR TITLE
Add handling for suspended state

### DIFF
--- a/custom_components/proxmoxve/coordinator.py
+++ b/custom_components/proxmoxve/coordinator.py
@@ -225,7 +225,7 @@ class ProxmoxQEMUCoordinator(ProxmoxCoordinator):
         update_device_via(self, ProxmoxType.QEMU)
         return ProxmoxVMData(
             type=ProxmoxType.QEMU,
-            status=api_status["status"],
+            status= api_status["lock"] if ("lock" in api_status and api_status["lock"] == "suspended") else api_status["status"],
             name=api_status["name"],
             node=self.node_name,
             health=api_status["qmpstatus"],

--- a/custom_components/proxmoxve/sensor.py
+++ b/custom_components/proxmoxve/sensor.py
@@ -314,7 +314,7 @@ PROXMOX_SENSOR_QEMU: Final[tuple[ProxmoxSensorEntityDescription, ...]] = (
         name="Status",
         icon="mdi:server",
         translation_key="status_raw",
-        value_fn=lambda x: "paused" if x.health == "paused" else x.status,
+        value_fn=lambda x: raw_status_process(x)
     ),
     *PROXMOX_SENSOR_CPU,
     *PROXMOX_SENSOR_DISK,
@@ -395,6 +395,11 @@ PROXMOX_SENSOR_DISKS: Final[tuple[ProxmoxSensorEntityDescription, ...]] = (
         translation_key="power_cycles",
     ),
 )
+
+def raw_status_process(vm):
+    if vm.health not in ["running", "stopped"]:
+        return vm.health
+    return vm.status
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/proxmoxve/sensor.py
+++ b/custom_components/proxmoxve/sensor.py
@@ -314,7 +314,7 @@ PROXMOX_SENSOR_QEMU: Final[tuple[ProxmoxSensorEntityDescription, ...]] = (
         name="Status",
         icon="mdi:server",
         translation_key="status_raw",
-        value_fn=lambda x: raw_status_process(x)
+        value_fn=lambda x: x.health if x.health not in ["running", "stopped"] else x.status,
     ),
     *PROXMOX_SENSOR_CPU,
     *PROXMOX_SENSOR_DISK,
@@ -395,11 +395,6 @@ PROXMOX_SENSOR_DISKS: Final[tuple[ProxmoxSensorEntityDescription, ...]] = (
         translation_key="power_cycles",
     ),
 )
-
-def raw_status_process(vm):
-    if vm.health not in ["running", "stopped"]:
-        return vm.health
-    return vm.status
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/proxmoxve/strings.json
+++ b/custom_components/proxmoxve/strings.json
@@ -237,6 +237,7 @@
         "state": {
           "paused": "Paused",
           "stopped": "Stopped",
+          "suspended": "Suspended",
           "running": "Running"
         }
       },

--- a/custom_components/proxmoxve/translations/en.json
+++ b/custom_components/proxmoxve/translations/en.json
@@ -1,274 +1,275 @@
 {
-    "config": {
-      "step": {
-        "host": {
-          "description": "Proxmox host information",
-          "data": {
-            "host": "Host",
+  "config": {
+    "step": {
+      "host": {
+        "description": "Proxmox host information",
+        "data": {
+          "host": "Host",
+          "password": "Password",
+          "port": "Port",
+          "realm": "Realm",
+          "username": "Username",
+          "verify_ssl": "Verify SSL certificate"
+        }
+      },
+      "expose": {
+        "description": "Select the Proxmox instance nodes, Virtual Machines (QEMU), Containers (LXC) and Storages you want to expose",
+        "data": {
+          "nodes": "Nodes",
+          "qemu": "Virtual Machines (QEMU)",
+          "lxc": "Linux Containers (LXC)",
+          "storage": "Storages"
+        }
+      },
+      "reauth_confirm": {
+        "description": "The username or password is invalid.",
+        "title": "Reauthenticate Integration",
+        "data": {
+          "password": "Password",
+          "username": "Username"
+        }
+      }
+    },
+    "error": {
+      "auth_error": "Invalid authentication",
+      "cant_connect": "Failed to connect",
+      "general_error": "Unexpected error",
+      "invalid_port": "Invalid port number",
+      "ssl_rejection": "Could not verify the SSL certificate"
+    },
+    "abort": {
+      "already_configured": "Device is already configured",
+      "no_resources": "No resources were returned for this instance.",
+      "reauth_successful": "Re-authentication was successful"
+    }
+  },
+  "issues": {
+    "import_success": {
+      "title": "{host}:{port} was imported from YAML configuration",
+      "description": "The YAML configuration of {host}:{port} instance of {integration} (`{platform}`) has been imported into the UI automatically.\n\nCan be safely removed from your `configuration.yaml` file."
+    },
+    "import_invalid_port": {
+      "title": "Error in importing YAML configuration from {host}:{port}",
+      "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to invalid port.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
+    },
+    "import_auth_error": {
+      "title": "Error in importing YAML configuration from {host}:{port}",
+      "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to authentication error.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
+    },
+    "import_ssl_rejection": {
+      "title": "Error in importing YAML configuration from {host}:{port}",
+      "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to SSL rejection.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
+    },
+    "import_cant_connect": {
+      "title": "Error in importing YAML configuration from {host}:{port}",
+      "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to connection failed.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
+    },
+    "import_general_error": {
+      "title": "Error in importing YAML configuration from {host}:{port}",
+      "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to unknown error.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
+    },
+    "import_already_configured": {
+      "title": "The instance {host}:{port} already exists in the UI, can be removed",
+      "description": "The YAML configuration of instace {host}:{port} of {integration} (`{platform}`) already exists in the UI and was ignored on import.\n\nYou must remove this configuration from your `configuration.yaml` file and restart Home Assistant."
+    },
+    "import_node_not_exist": {
+      "title": "Node {node} does not exist in {host}:{port}",
+      "description": "The {node} of the {host}:{port} instance of {integration} (`{platform}`) present in the YAML configuration does not exist in this instance and was ignored in the import.\n\nYou must remove this configuration from your `configuration.yaml` file and restart Home Assistant."
+    },
+    "yaml_deprecated": {
+      "title": "Configuration of the {integration} in YAML is deprecated",
+      "description": "Configuration of the {integration} (`{platform}`) in YAML is deprecated and should be removed in {version}.\n\nResolve the import issues and remove the YAML configuration from your `configuration.yaml` file."
+    },
+    "resource_nonexistent": {
+      "description": "{resource_type} {resource} does not exist on ({host}:{port}), remove it in integration options.\n\nThis can also be caused if the user doesn't have enough permission to access the resource.\n\nTip on required permissions:\n* `{permission}`",
+      "title": "{resource_type} {resource} does not exist"
+    },
+    "no_permissions": {
+      "description": "The user `{user}` does not have the required permissions for all features.\n\nThe following features are not accessible by the user:\n`{errors}`\n\nCheck the user permissions as described in the documentation.",
+      "title": "User `{user}` does not have the required permissions"
+    },
+    "resource_exception_forbiden": {
+      "description": "User `{user}` does not have sufficient permissions to access resource `{resource}`.\n\nTip on required permissions:\n* `{permission}`\n\nPlease check documentation and user permissions.",
+      "title": "Permissions error for `{resource}`"
+    },
+    "resource_command_forbiden": {
+      "description": "User `{user}` does not have sufficient permissions to execute command `{command}` on resource `{resource}`.\n\nTip on required permissions:\n* `{permission}`\n\nPlease check documentation and user permissions.",
+      "title": "Permission error for `{resource}` command"
+    }
+  },
+  "options": {
+    "step": {
+      "menu": {
+        "menu_options": {
+          "host_auth": "Change host authentication information",
+          "change_expose": "Add or remove Nodes, VMs, Containers or Storages"
+        }
+      },
+      "host_auth": {
+        "data": {
             "password": "Password",
-            "port": "Port",
             "realm": "Realm",
             "username": "Username",
             "verify_ssl": "Verify SSL certificate"
-          }
         },
-        "expose": {
-          "description": "Select the Proxmox instance nodes, Virtual Machines (QEMU), Containers (LXC) and Storages you want to expose",
-          "data": {
-            "nodes": "Nodes",
-            "qemu": "Virtual Machines (QEMU)",
-            "lxc": "Linux Containers (LXC)",
-            "storage": "Storages"
-          }
-        },
-        "reauth_confirm": {
-          "description": "The username or password is invalid.",
-          "title": "Reauthenticate Integration",
-          "data": {
-            "password": "Password",
-            "username": "Username"
-          }
+        "description": "Proxmox host information"
+      },
+      "change_expose": {
+        "description": "Select the Proxmox instance nodes ans Virtual Machines (QEMU) and Containers (LXC) you want to expose",
+        "data": {
+          "lxc": "Linux Containers (LXC)",
+          "nodes": "Nodes",
+          "qemu": "Virtual Machines (QEMU)",
+          "storage": "Storages"
         }
-      },
-      "error": {
-        "auth_error": "Invalid authentication",
-        "cant_connect": "Failed to connect",
-        "general_error": "Unexpected error",
-        "invalid_port": "Invalid port number",
-        "ssl_rejection": "Could not verify the SSL certificate"
-      },
-      "abort": {
-        "already_configured": "Device is already configured",
-        "no_resources": "No resources were returned for this instance.",
-        "reauth_successful": "Re-authentication was successful"
       }
     },
-    "issues": {
-      "import_success": {
-        "title": "{host}:{port} was imported from YAML configuration",
-        "description": "The YAML configuration of {host}:{port} instance of {integration} (`{platform}`) has been imported into the UI automatically.\n\nCan be safely removed from your `configuration.yaml` file."
+    "error": {
+      "auth_error": "Invalid authentication",
+      "cant_connect": "Failed to connect",
+      "general_error": "Unexpected error",
+      "invalid_port": "Invalid port number",
+      "ssl_rejection": "Could not verify the SSL certificate"
+    },
+    "abort": {
+      "no_nodes": "No nodes were returned for the host.",
+      "no_vms": "There are no virtual machines or containers for this node, the configuration entry will be created for the node.",
+      "changes_successful": "Changes saved successfully.",
+      "no_nodes_to_add": "No nodes to add.",
+      "node_already_exists": "The selected node already exists."
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "status": {
+        "name": "Status"
       },
-      "import_invalid_port": {
-        "title": "Error in importing YAML configuration from {host}:{port}",
-        "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to invalid port.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
+      "health": {
+        "name": "Health"
       },
-      "import_auth_error": {
-        "title": "Error in importing YAML configuration from {host}:{port}",
-        "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to authentication error.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
-      },
-      "import_ssl_rejection": {
-        "title": "Error in importing YAML configuration from {host}:{port}",
-        "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to SSL rejection.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
-      },
-      "import_cant_connect": {
-        "title": "Error in importing YAML configuration from {host}:{port}",
-        "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to connection failed.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
-      },
-      "import_general_error": {
-        "title": "Error in importing YAML configuration from {host}:{port}",
-        "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to unknown error.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
-      },
-      "import_already_configured": {
-        "title": "The instance {host}:{port} already exists in the UI, can be removed",
-        "description": "The YAML configuration of instace {host}:{port} of {integration} (`{platform}`) already exists in the UI and was ignored on import.\n\nYou must remove this configuration from your `configuration.yaml` file and restart Home Assistant."
-      },
-      "import_node_not_exist": {
-        "title": "Node {node} does not exist in {host}:{port}",
-        "description": "The {node} of the {host}:{port} instance of {integration} (`{platform}`) present in the YAML configuration does not exist in this instance and was ignored in the import.\n\nYou must remove this configuration from your `configuration.yaml` file and restart Home Assistant."
-      },
-      "yaml_deprecated": {
-        "title": "Configuration of the {integration} in YAML is deprecated",
-        "description": "Configuration of the {integration} (`{platform}`) in YAML is deprecated and should be removed in {version}.\n\nResolve the import issues and remove the YAML configuration from your `configuration.yaml` file."
-      },
-      "resource_nonexistent": {
-        "description": "{resource_type} {resource} does not exist on ({host}:{port}), remove it in integration options.\n\nThis can also be caused if the user doesn't have enough permission to access the resource.\n\nTip on required permissions:\n* `{permission}`",
-        "title": "{resource_type} {resource} does not exist"
-      },
-      "no_permissions": {
-        "description": "The user `{user}` does not have the required permissions for all features.\n\nThe following features are not accessible by the user:\n`{errors}`\n\nCheck the user permissions as described in the documentation.",
-        "title": "User `{user}` does not have the required permissions"
-      },
-      "resource_exception_forbiden": {
-        "description": "User `{user}` does not have sufficient permissions to access resource `{resource}`.\n\nTip on required permissions:\n* `{permission}`\n\nPlease check documentation and user permissions.",
-        "title": "Permissions error for `{resource}`"
-      },
-      "resource_command_forbiden": {
-        "description": "User `{user}` does not have sufficient permissions to execute command `{command}` on resource `{resource}`.\n\nTip on required permissions:\n* `{permission}`\n\nPlease check documentation and user permissions.",
-        "title": "Permission error for `{resource}` command"
+      "update_avail": {
+        "name": "Updates packages"
       }
     },
-    "options": {
-      "step": {
-        "menu": {
-          "menu_options": {
-            "host_auth": "Change host authentication information",
-            "change_expose": "Add or remove Nodes, VMs, Containers or Storages"
-          }
-        },
-        "host_auth": {
-          "data": {
-              "password": "Password",
-              "realm": "Realm",
-              "username": "Username",
-              "verify_ssl": "Verify SSL certificate"
-          },
-          "description": "Proxmox host information"
-        },
-        "change_expose": {
-          "description": "Select the Proxmox instance nodes ans Virtual Machines (QEMU) and Containers (LXC) you want to expose",
-          "data": {
-            "lxc": "Linux Containers (LXC)",
-            "nodes": "Nodes",
-            "qemu": "Virtual Machines (QEMU)",
-            "storage": "Storages"
-          }
-        }
+    "button": {
+      "start_all": {
+        "name": "Start all"
       },
-      "error": {
-        "auth_error": "Invalid authentication",
-        "cant_connect": "Failed to connect",
-        "general_error": "Unexpected error",
-        "invalid_port": "Invalid port number",
-        "ssl_rejection": "Could not verify the SSL certificate"
+      "stop_all": {
+        "name": "Stop all"
       },
-      "abort": {
-        "no_nodes": "No nodes were returned for the host.",
-        "no_vms": "There are no virtual machines or containers for this node, the configuration entry will be created for the node.",
-        "changes_successful": "Changes saved successfully.",
-        "no_nodes_to_add": "No nodes to add.",
-        "node_already_exists": "The selected node already exists."
+      "shutdown": {
+        "name": "Shutdown"
+      },
+      "reboot": {
+        "name": "Reboot"
+      },
+      "start": {
+        "name": "Start"
+      },
+      "stop": {
+        "name": "Stop"
+      },
+      "resume": {
+        "name": "Resume"
+      },
+      "suspend": {
+        "name": "Suspend"
+      },
+      "reset": {
+        "name": "Reset"
       }
     },
-    "entity": {
-      "binary_sensor": {
-        "status": {
-          "name": "Status"
-        },
-        "health": {
-          "name": "Health"
-        },
-        "update_avail": {
-          "name": "Updates packages"
+    "sensor": {
+      "cpu_used": {
+        "name": "CPU used"
+      },
+      "disk_free": {
+        "name": "Disk free"
+      },
+      "disk_free_perc": {
+        "name": "Disk free percentage"
+      },
+      "disk_rpm": {
+        "name": "Disk speed"
+      },
+      "disk_size": {
+        "name": "Size"
+      },
+      "disk_total": {
+        "name": "Disk total"
+      },
+      "disk_used": {
+        "name": "Disk used"
+      },
+      "disk_used_perc": {
+        "name": "Disk used percentage"
+      },
+      "memory_free": {
+        "name": "Memory free"
+      },
+      "memory_free_perc": {
+        "name": "Memory free percentage"
+      },
+      "memory_total": {
+        "name": "Memory total"
+      },
+      "memory_used": {
+        "name": "Memory used"
+      },
+      "memory_used_perc": {
+        "name": "Memory used percentage"
+      },
+      "network_in": {
+        "name": "Network in"
+      },
+      "network_out": {
+        "name": "Network out"
+      },
+      "node": {
+        "name": "Node"
+      },
+      "power_cycles": {
+        "name": "Power cycles"
+      },
+      "status_raw": {
+        "name": "Status",
+        "state": {
+          "paused": "Paused",
+          "stopped": "Stopped",
+          "suspended": "Suspended",
+          "running": "Running"
         }
       },
-      "button": {
-        "start_all": {
-          "name": "Start all"
-        },
-        "stop_all": {
-          "name": "Stop all"
-        },
-        "shutdown": {
-          "name": "Shutdown"
-        },
-        "reboot": {
-          "name": "Reboot"
-        },
-        "start": {
-          "name": "Start"
-        },
-        "stop": {
-          "name": "Stop"
-        },
-        "resume": {
-          "name": "Resume"
-        },
-        "suspend": {
-          "name": "Suspend"
-        },
-        "reset": {
-          "name": "Reset"
+      "swap_free": {
+        "name": "Swap free"
+      },
+      "swap_free_perc": {
+        "name": "Swap free percentage"
+      },
+      "swap_total": {
+        "name": "Swap total"
+      },
+      "swap_used": {
+        "name": "Swap used"
+      },
+      "swap_used_perc": {
+        "name": "Swap used percentage"
+      },
+      "temperature": {
+        "name": "Temperature"
+      },
+      "updates_total": {
+        "name": "Total updates",
+        "state_attributes": {
+          "updates_list": {
+            "name": "Updates list"
+          }
         }
       },
-      "sensor": {
-        "cpu_used": {
-          "name": "CPU used"
-        },
-        "disk_free": {
-          "name": "Disk free"
-        },
-        "disk_free_perc": {
-          "name": "Disk free percentage"
-        },
-        "disk_rpm": {
-          "name": "Disk speed"
-        },
-        "disk_size": {
-          "name": "Size"
-        },
-        "disk_total": {
-          "name": "Disk total"
-        },
-        "disk_used": {
-          "name": "Disk used"
-        },
-        "disk_used_perc": {
-          "name": "Disk used percentage"
-        },
-        "memory_free": {
-          "name": "Memory free"
-        },
-        "memory_free_perc": {
-          "name": "Memory free percentage"
-        },
-        "memory_total": {
-          "name": "Memory total"
-        },
-        "memory_used": {
-          "name": "Memory used"
-        },
-        "memory_used_perc": {
-          "name": "Memory used percentage"
-        },
-        "network_in": {
-          "name": "Network in"
-        },
-        "network_out": {
-          "name": "Network out"
-        },
-        "node": {
-          "name": "Node"
-        },
-        "power_cycles": {
-          "name": "Power cycles"
-        },
-        "status_raw": {
-          "name": "Status",
-          "state": {
-            "paused": "Paused",
-            "stopped": "Stopped",
-            "running": "Running"
-          }
-        },
-        "swap_free": {
-          "name": "Swap free"
-        },
-        "swap_free_perc": {
-          "name": "Swap free percentage"
-        },
-        "swap_total": {
-          "name": "Swap total"
-        },
-        "swap_used": {
-          "name": "Swap used"
-        },
-        "swap_used_perc": {
-          "name": "Swap used percentage"
-        },
-        "temperature": {
-          "name": "Temperature"
-        },
-        "updates_total": {
-          "name": "Total updates",
-          "state_attributes": {
-            "updates_list": {
-              "name": "Updates list"
-            }
-          }
-        },
-        "uptime": {
-          "name": "Uptime"
-        }
+      "uptime": {
+        "name": "Uptime"
       }
     }
   }
+}

--- a/custom_components/proxmoxve/translations/en.json
+++ b/custom_components/proxmoxve/translations/en.json
@@ -1,275 +1,283 @@
 {
-  "config": {
-    "step": {
-      "host": {
-        "description": "Proxmox host information",
-        "data": {
-          "host": "Host",
-          "password": "Password",
-          "port": "Port",
-          "realm": "Realm",
-          "username": "Username",
-          "verify_ssl": "Verify SSL certificate"
-        }
-      },
-      "expose": {
-        "description": "Select the Proxmox instance nodes, Virtual Machines (QEMU), Containers (LXC) and Storages you want to expose",
-        "data": {
-          "nodes": "Nodes",
-          "qemu": "Virtual Machines (QEMU)",
-          "lxc": "Linux Containers (LXC)",
-          "storage": "Storages"
-        }
-      },
-      "reauth_confirm": {
-        "description": "The username or password is invalid.",
-        "title": "Reauthenticate Integration",
-        "data": {
-          "password": "Password",
-          "username": "Username"
-        }
-      }
-    },
-    "error": {
-      "auth_error": "Invalid authentication",
-      "cant_connect": "Failed to connect",
-      "general_error": "Unexpected error",
-      "invalid_port": "Invalid port number",
-      "ssl_rejection": "Could not verify the SSL certificate"
-    },
-    "abort": {
-      "already_configured": "Device is already configured",
-      "no_resources": "No resources were returned for this instance.",
-      "reauth_successful": "Re-authentication was successful"
-    }
-  },
-  "issues": {
-    "import_success": {
-      "title": "{host}:{port} was imported from YAML configuration",
-      "description": "The YAML configuration of {host}:{port} instance of {integration} (`{platform}`) has been imported into the UI automatically.\n\nCan be safely removed from your `configuration.yaml` file."
-    },
-    "import_invalid_port": {
-      "title": "Error in importing YAML configuration from {host}:{port}",
-      "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to invalid port.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
-    },
-    "import_auth_error": {
-      "title": "Error in importing YAML configuration from {host}:{port}",
-      "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to authentication error.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
-    },
-    "import_ssl_rejection": {
-      "title": "Error in importing YAML configuration from {host}:{port}",
-      "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to SSL rejection.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
-    },
-    "import_cant_connect": {
-      "title": "Error in importing YAML configuration from {host}:{port}",
-      "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to connection failed.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
-    },
-    "import_general_error": {
-      "title": "Error in importing YAML configuration from {host}:{port}",
-      "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to unknown error.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
-    },
-    "import_already_configured": {
-      "title": "The instance {host}:{port} already exists in the UI, can be removed",
-      "description": "The YAML configuration of instace {host}:{port} of {integration} (`{platform}`) already exists in the UI and was ignored on import.\n\nYou must remove this configuration from your `configuration.yaml` file and restart Home Assistant."
-    },
-    "import_node_not_exist": {
-      "title": "Node {node} does not exist in {host}:{port}",
-      "description": "The {node} of the {host}:{port} instance of {integration} (`{platform}`) present in the YAML configuration does not exist in this instance and was ignored in the import.\n\nYou must remove this configuration from your `configuration.yaml` file and restart Home Assistant."
-    },
-    "yaml_deprecated": {
-      "title": "Configuration of the {integration} in YAML is deprecated",
-      "description": "Configuration of the {integration} (`{platform}`) in YAML is deprecated and should be removed in {version}.\n\nResolve the import issues and remove the YAML configuration from your `configuration.yaml` file."
-    },
-    "resource_nonexistent": {
-      "description": "{resource_type} {resource} does not exist on ({host}:{port}), remove it in integration options.\n\nThis can also be caused if the user doesn't have enough permission to access the resource.\n\nTip on required permissions:\n* `{permission}`",
-      "title": "{resource_type} {resource} does not exist"
-    },
-    "no_permissions": {
-      "description": "The user `{user}` does not have the required permissions for all features.\n\nThe following features are not accessible by the user:\n`{errors}`\n\nCheck the user permissions as described in the documentation.",
-      "title": "User `{user}` does not have the required permissions"
-    },
-    "resource_exception_forbiden": {
-      "description": "User `{user}` does not have sufficient permissions to access resource `{resource}`.\n\nTip on required permissions:\n* `{permission}`\n\nPlease check documentation and user permissions.",
-      "title": "Permissions error for `{resource}`"
-    },
-    "resource_command_forbiden": {
-      "description": "User `{user}` does not have sufficient permissions to execute command `{command}` on resource `{resource}`.\n\nTip on required permissions:\n* `{permission}`\n\nPlease check documentation and user permissions.",
-      "title": "Permission error for `{resource}` command"
-    }
-  },
-  "options": {
-    "step": {
-      "menu": {
-        "menu_options": {
-          "host_auth": "Change host authentication information",
-          "change_expose": "Add or remove Nodes, VMs, Containers or Storages"
-        }
-      },
-      "host_auth": {
-        "data": {
+    "config": {
+      "step": {
+        "host": {
+          "description": "Proxmox host information",
+          "data": {
+            "host": "Host",
             "password": "Password",
+            "port": "Port",
             "realm": "Realm",
             "username": "Username",
             "verify_ssl": "Verify SSL certificate"
+          }
         },
-        "description": "Proxmox host information"
-      },
-      "change_expose": {
-        "description": "Select the Proxmox instance nodes ans Virtual Machines (QEMU) and Containers (LXC) you want to expose",
-        "data": {
-          "lxc": "Linux Containers (LXC)",
-          "nodes": "Nodes",
-          "qemu": "Virtual Machines (QEMU)",
-          "storage": "Storages"
-        }
-      }
-    },
-    "error": {
-      "auth_error": "Invalid authentication",
-      "cant_connect": "Failed to connect",
-      "general_error": "Unexpected error",
-      "invalid_port": "Invalid port number",
-      "ssl_rejection": "Could not verify the SSL certificate"
-    },
-    "abort": {
-      "no_nodes": "No nodes were returned for the host.",
-      "no_vms": "There are no virtual machines or containers for this node, the configuration entry will be created for the node.",
-      "changes_successful": "Changes saved successfully.",
-      "no_nodes_to_add": "No nodes to add.",
-      "node_already_exists": "The selected node already exists."
-    }
-  },
-  "entity": {
-    "binary_sensor": {
-      "status": {
-        "name": "Status"
-      },
-      "health": {
-        "name": "Health"
-      },
-      "update_avail": {
-        "name": "Updates packages"
-      }
-    },
-    "button": {
-      "start_all": {
-        "name": "Start all"
-      },
-      "stop_all": {
-        "name": "Stop all"
-      },
-      "shutdown": {
-        "name": "Shutdown"
-      },
-      "reboot": {
-        "name": "Reboot"
-      },
-      "start": {
-        "name": "Start"
-      },
-      "stop": {
-        "name": "Stop"
-      },
-      "resume": {
-        "name": "Resume"
-      },
-      "suspend": {
-        "name": "Suspend"
-      },
-      "reset": {
-        "name": "Reset"
-      }
-    },
-    "sensor": {
-      "cpu_used": {
-        "name": "CPU used"
-      },
-      "disk_free": {
-        "name": "Disk free"
-      },
-      "disk_free_perc": {
-        "name": "Disk free percentage"
-      },
-      "disk_rpm": {
-        "name": "Disk speed"
-      },
-      "disk_size": {
-        "name": "Size"
-      },
-      "disk_total": {
-        "name": "Disk total"
-      },
-      "disk_used": {
-        "name": "Disk used"
-      },
-      "disk_used_perc": {
-        "name": "Disk used percentage"
-      },
-      "memory_free": {
-        "name": "Memory free"
-      },
-      "memory_free_perc": {
-        "name": "Memory free percentage"
-      },
-      "memory_total": {
-        "name": "Memory total"
-      },
-      "memory_used": {
-        "name": "Memory used"
-      },
-      "memory_used_perc": {
-        "name": "Memory used percentage"
-      },
-      "network_in": {
-        "name": "Network in"
-      },
-      "network_out": {
-        "name": "Network out"
-      },
-      "node": {
-        "name": "Node"
-      },
-      "power_cycles": {
-        "name": "Power cycles"
-      },
-      "status_raw": {
-        "name": "Status",
-        "state": {
-          "paused": "Paused",
-          "stopped": "Stopped",
-          "suspended": "Suspended",
-          "running": "Running"
-        }
-      },
-      "swap_free": {
-        "name": "Swap free"
-      },
-      "swap_free_perc": {
-        "name": "Swap free percentage"
-      },
-      "swap_total": {
-        "name": "Swap total"
-      },
-      "swap_used": {
-        "name": "Swap used"
-      },
-      "swap_used_perc": {
-        "name": "Swap used percentage"
-      },
-      "temperature": {
-        "name": "Temperature"
-      },
-      "updates_total": {
-        "name": "Total updates",
-        "state_attributes": {
-          "updates_list": {
-            "name": "Updates list"
+        "expose": {
+          "description": "Select the Proxmox instance nodes, Virtual Machines (QEMU), Containers (LXC) and Storages you want to expose",
+          "data": {
+            "nodes": "Nodes",
+            "qemu": "Virtual Machines (QEMU)",
+            "lxc": "Linux Containers (LXC)",
+            "storage": "Storages",
+            "disks_enable": "Enable physical disk information"
+          },
+          "data_description": {
+            "disks_enable": "If you configure disk hibernation, you must disable this option as it will prevent the disks from remaining in hibernation."
+          }
+        },
+        "reauth_confirm": {
+          "description": "The username or password is invalid.",
+          "title": "Reauthenticate Integration",
+          "data": {
+            "password": "Password",
+            "username": "Username"
           }
         }
       },
-      "uptime": {
-        "name": "Uptime"
+      "error": {
+        "auth_error": "Invalid authentication",
+        "cant_connect": "Failed to connect",
+        "general_error": "Unexpected error",
+        "invalid_port": "Invalid port number",
+        "ssl_rejection": "Could not verify the SSL certificate"
+      },
+      "abort": {
+        "already_configured": "Device is already configured",
+        "no_resources": "No resources were returned for this instance.",
+        "reauth_successful": "Re-authentication was successful"
+      }
+    },
+    "issues": {
+      "import_success": {
+        "title": "{host}:{port} was imported from YAML configuration",
+        "description": "The YAML configuration of {host}:{port} instance of {integration} (`{platform}`) has been imported into the UI automatically.\n\nCan be safely removed from your `configuration.yaml` file."
+      },
+      "import_invalid_port": {
+        "title": "Error in importing YAML configuration from {host}:{port}",
+        "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to invalid port.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
+      },
+      "import_auth_error": {
+        "title": "Error in importing YAML configuration from {host}:{port}",
+        "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to authentication error.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
+      },
+      "import_ssl_rejection": {
+        "title": "Error in importing YAML configuration from {host}:{port}",
+        "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to SSL rejection.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
+      },
+      "import_cant_connect": {
+        "title": "Error in importing YAML configuration from {host}:{port}",
+        "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to connection failed.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
+      },
+      "import_general_error": {
+        "title": "Error in importing YAML configuration from {host}:{port}",
+        "description": "Importing YAML configuration from {host}:{port} instance of {integration} (`{platform}`) failed due to unknown error.\n\nYou must remove this configuration from your `configuration.yaml` file, restart Home Assistant and configure it manually."
+      },
+      "import_already_configured": {
+        "title": "The instance {host}:{port} already exists in the UI, can be removed",
+        "description": "The YAML configuration of instace {host}:{port} of {integration} (`{platform}`) already exists in the UI and was ignored on import.\n\nYou must remove this configuration from your `configuration.yaml` file and restart Home Assistant."
+      },
+      "import_node_not_exist": {
+        "title": "Node {node} does not exist in {host}:{port}",
+        "description": "The {node} of the {host}:{port} instance of {integration} (`{platform}`) present in the YAML configuration does not exist in this instance and was ignored in the import.\n\nYou must remove this configuration from your `configuration.yaml` file and restart Home Assistant."
+      },
+      "yaml_deprecated": {
+        "title": "Configuration of the {integration} in YAML is deprecated",
+        "description": "Configuration of the {integration} (`{platform}`) in YAML is deprecated and should be removed in {version}.\n\nResolve the import issues and remove the YAML configuration from your `configuration.yaml` file."
+      },
+      "resource_nonexistent": {
+        "description": "{resource_type} {resource} does not exist on ({host}:{port}), remove it in integration options.\n\nThis can also be caused if the user doesn't have enough permission to access the resource.\n\nTip on required permissions:\n* `{permission}`",
+        "title": "{resource_type} {resource} does not exist"
+      },
+      "no_permissions": {
+        "description": "The user `{user}` does not have the required permissions for all features.\n\nThe following features are not accessible by the user:\n`{errors}`\n\nCheck the user permissions as described in the documentation.",
+        "title": "User `{user}` does not have the required permissions"
+      },
+      "resource_exception_forbiden": {
+        "description": "User `{user}` does not have sufficient permissions to access resource `{resource}`.\n\nTip on required permissions:\n* `{permission}`\n\nPlease check documentation and user permissions.",
+        "title": "Permissions error for `{resource}`"
+      },
+      "resource_command_forbiden": {
+        "description": "User `{user}` does not have sufficient permissions to execute command `{command}` on resource `{resource}`.\n\nTip on required permissions:\n* `{permission}`\n\nPlease check documentation and user permissions.",
+        "title": "Permission error for `{resource}` command"
+      }
+    },
+    "options": {
+      "step": {
+        "menu": {
+          "menu_options": {
+            "host_auth": "Change host authentication information",
+            "change_expose": "Add or remove Nodes, VMs, Containers or Storages"
+          }
+        },
+        "host_auth": {
+          "data": {
+              "password": "Password",
+              "realm": "Realm",
+              "username": "Username",
+              "verify_ssl": "Verify SSL certificate"
+          },
+          "description": "Proxmox host information"
+        },
+        "change_expose": {
+          "description": "Select the Proxmox instance nodes ans Virtual Machines (QEMU) and Containers (LXC) you want to expose",
+          "data": {
+            "lxc": "Linux Containers (LXC)",
+            "nodes": "Nodes",
+            "qemu": "Virtual Machines (QEMU)",
+            "storage": "Storages",
+            "disks_enable": "Enable physical disk information"
+          },
+          "data_description": {
+            "disks_enable": "If you configure disk hibernation, you must disable this option as it will prevent the disks from remaining in hibernation."
+          }
+        }
+      },
+      "error": {
+        "auth_error": "Invalid authentication",
+        "cant_connect": "Failed to connect",
+        "general_error": "Unexpected error",
+        "invalid_port": "Invalid port number",
+        "ssl_rejection": "Could not verify the SSL certificate"
+      },
+      "abort": {
+        "no_nodes": "No nodes were returned for the host.",
+        "no_vms": "There are no virtual machines or containers for this node, the configuration entry will be created for the node.",
+        "changes_successful": "Changes saved successfully.",
+        "no_nodes_to_add": "No nodes to add.",
+        "node_already_exists": "The selected node already exists."
+      }
+    },
+    "entity": {
+      "binary_sensor": {
+        "status": {
+          "name": "Status"
+        },
+        "health": {
+          "name": "Health"
+        },
+        "update_avail": {
+          "name": "Updates packages"
+        }
+      },
+      "button": {
+        "start_all": {
+          "name": "Start all"
+        },
+        "stop_all": {
+          "name": "Stop all"
+        },
+        "shutdown": {
+          "name": "Shutdown"
+        },
+        "reboot": {
+          "name": "Reboot"
+        },
+        "start": {
+          "name": "Start"
+        },
+        "stop": {
+          "name": "Stop"
+        },
+        "resume": {
+          "name": "Resume"
+        },
+        "suspend": {
+          "name": "Suspend"
+        },
+        "reset": {
+          "name": "Reset"
+        }
+      },
+      "sensor": {
+        "cpu_used": {
+          "name": "CPU used"
+        },
+        "disk_free": {
+          "name": "Disk free"
+        },
+        "disk_free_perc": {
+          "name": "Disk free percentage"
+        },
+        "disk_rpm": {
+          "name": "Disk speed"
+        },
+        "disk_size": {
+          "name": "Size"
+        },
+        "disk_total": {
+          "name": "Disk total"
+        },
+        "disk_used": {
+          "name": "Disk used"
+        },
+        "disk_used_perc": {
+          "name": "Disk used percentage"
+        },
+        "memory_free": {
+          "name": "Memory free"
+        },
+        "memory_free_perc": {
+          "name": "Memory free percentage"
+        },
+        "memory_total": {
+          "name": "Memory total"
+        },
+        "memory_used": {
+          "name": "Memory used"
+        },
+        "memory_used_perc": {
+          "name": "Memory used percentage"
+        },
+        "network_in": {
+          "name": "Network in"
+        },
+        "network_out": {
+          "name": "Network out"
+        },
+        "node": {
+          "name": "Node"
+        },
+        "power_cycles": {
+          "name": "Power cycles"
+        },
+        "status_raw": {
+          "name": "Status",
+          "state": {
+            "paused": "Paused",
+            "stopped": "Stopped",
+            "suspended": "Suspended",
+            "running": "Running"
+          }
+        },
+        "swap_free": {
+          "name": "Swap free"
+        },
+        "swap_free_perc": {
+          "name": "Swap free percentage"
+        },
+        "swap_total": {
+          "name": "Swap total"
+        },
+        "swap_used": {
+          "name": "Swap used"
+        },
+        "swap_used_perc": {
+          "name": "Swap used percentage"
+        },
+        "temperature": {
+          "name": "Temperature"
+        },
+        "updates_total": {
+          "name": "Total updates",
+          "state_attributes": {
+            "updates_list": {
+              "name": "Updates list"
+            }
+          }
+        },
+        "uptime": {
+          "name": "Uptime"
+        }
       }
     }
   }
-}

--- a/custom_components/proxmoxve/translations/en.json
+++ b/custom_components/proxmoxve/translations/en.json
@@ -18,11 +18,7 @@
             "nodes": "Nodes",
             "qemu": "Virtual Machines (QEMU)",
             "lxc": "Linux Containers (LXC)",
-            "storage": "Storages",
-            "disks_enable": "Enable physical disk information"
-          },
-          "data_description": {
-            "disks_enable": "If you configure disk hibernation, you must disable this option as it will prevent the disks from remaining in hibernation."
+            "storage": "Storages"
           }
         },
         "reauth_confirm": {
@@ -124,11 +120,7 @@
             "lxc": "Linux Containers (LXC)",
             "nodes": "Nodes",
             "qemu": "Virtual Machines (QEMU)",
-            "storage": "Storages",
-            "disks_enable": "Enable physical disk information"
-          },
-          "data_description": {
-            "disks_enable": "If you configure disk hibernation, you must disable this option as it will prevent the disks from remaining in hibernation."
+            "storage": "Storages"
           }
         }
       },

--- a/custom_components/proxmoxve/translations/pt-BR.json
+++ b/custom_components/proxmoxve/translations/pt-BR.json
@@ -149,6 +149,7 @@
             "state": {
               "paused": "Pausado",
               "stopped": "Desligado",
+              "suspended": "Suspenso",
               "running": "Executando"
             }
           },


### PR DESCRIPTION
Currently there are 3 supported states in the new status sensor:  _"Running", "Stopped", "Paused"_ when a machine goes to sleep by itself it is put into a "Suspended" state. This PR adds support for that case but only for EN locale.


As you can see from this image "Suspended" is now a supported state.

![image](https://github.com/dougiteixeira/proxmoxve/assets/25233576/fef1416c-5226-4608-be17-86e36152b333)
