### PR TITLE
Change the Home Assistant minimum version requirement to 2024.1.0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -6,6 +6,6 @@
     "sensor"
   ],
   "iot_class": "local_push",
-  "homeassistant": "2023.11.0",
+  "homeassistant": "2024.1.0",
   "render_readme": true
 }


### PR DESCRIPTION
## ⚠️ Break change
The integration is only compatible with the latest versions of Home Assistant (2024.1.0 or higher).
Updating to version 3.3.0 or higher on older versions of Home Assistant will break custom integration.