### PR TITLE
Fix storage handling

### DIFF
--- a/custom_components/proxmoxve/config_flow.py
+++ b/custom_components/proxmoxve/config_flow.py
@@ -246,13 +246,7 @@ class ProxmoxOptionsFlowHandler(config_entries.OptionsFlow):
                         resource_lxc[str(resource["vmid"])] = f"{resource['vmid']}"
                 if ("type" in resource) and (resource["type"] == ProxmoxType.Storage):
                     if "storage" in resource:
-                        resource_storage[str(resource["storage"])] = (
-                            f"{resource['storage']} {resource['id']}"
-                        )
-                    else:
-                        resource_storage[str(resource["storage"])] = (
-                            f"{resource['storage']}"
-                        )
+                        resource_storage[str(resource["id"])] = resource["id"]
 
             return self.async_show_form(
                 step_id="change_expose",

--- a/custom_components/proxmoxve/config_flow.py
+++ b/custom_components/proxmoxve/config_flow.py
@@ -463,7 +463,7 @@ class ProxmoxOptionsFlowHandler(config_entries.OptionsFlow):
 class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """ProxmoxVE Config Flow class."""
 
-    VERSION = 4
+    VERSION = 5
     _reauth_entry: config_entries.ConfigEntry | None = None
 
     def __init__(self) -> None:

--- a/custom_components/proxmoxve/coordinator.py
+++ b/custom_components/proxmoxve/coordinator.py
@@ -419,7 +419,7 @@ class ProxmoxStorageCoordinator(ProxmoxCoordinator):
 
         for resource in resources if resources is not None else []:
             if "storage" in resource:
-                if resource["storage"] == self.resource_id:
+                if resource["id"] == self.resource_id:
                     node_name = resource["node"]
 
         api_path = "cluster/resources?type=storage"
@@ -435,13 +435,12 @@ class ProxmoxStorageCoordinator(ProxmoxCoordinator):
 
         api_status = []
         for api_storage in api_storages:
-            if api_storage["storage"] == self.resource_id:
+            if api_storage["id"] == self.resource_id:
                 api_status = api_storage
 
         if api_status is None or "content" not in api_status:
             raise UpdateFailed(f"Storage {self.resource_id} unable to be found")
 
-        update_device_via(self, ProxmoxType.Storage, node_name)
         storage_id = api_status["id"]
         name = f"Storage {storage_id.replace("storage/", "")}"
         return ProxmoxStorageData(


### PR DESCRIPTION
Fixes #319 and #321

After the update, the current devices and storage entities will be removed. The user must select again the storages they wish to expose in the integration configuration options.