### PR TITLE
Add config option for update information

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ Below is a summary of the permissions for each integration feature. I suggest yo
 |Get information about available package updates to display on sensors (integration does not trigger the update)|Management permission|HomeAssistant.Update|Sys.Modify|
 |Perform commands on VM/CT (start, shutdown, restart, suspend, resume and hibernate)|Management permission|HomeAssistant.VMPowerMgmt|VM.PowerMgmt|
 
+#### Disable update information to avoid needing Sys.Modify permission
+
+As Proxmox VE documentation states that `Sys.Modify` permissions should be handled with care, you can opt-out of polling the update information from your Proxmox instance to avoid permission errors.
+
+1. Navigate to your Home Assistant instance.
+2. In the sidebar, click Settings.
+3. From the Setup menu, select: Devices & Services.
+4. Search and select `Proxmox VE`.
+5. Click on `Configure` button of your instance
+6. Go to `Nodes, containers, …` setting
+7. Toggle `Enable update information` off
+8. Click `OK`
+
 ### Create Home Assistant Group
 
 Before creating the user, we need to create a group for the user.

--- a/custom_components/proxmoxve/__init__.py
+++ b/custom_components/proxmoxve/__init__.py
@@ -422,14 +422,15 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             if coordinator_node.data is not None:
                 nodes_add_device.append(node)
 
-            coordinator_updates = ProxmoxUpdateCoordinator(
-                hass=hass,
-                proxmox=proxmox,
-                api_category=ProxmoxType.Update,
-                node_name=node,
-            )
-            await coordinator_updates.async_refresh()
-            coordinators[f"{ProxmoxType.Update}_{node}"] = coordinator_updates
+            if config_entry.options.get(CONF_UPDATE_ENABLE, True):
+                coordinator_updates = ProxmoxUpdateCoordinator(
+                    hass=hass,
+                    proxmox=proxmox,
+                    api_category=ProxmoxType.Update,
+                    node_name=node,
+                )
+                await coordinator_updates.async_refresh()
+                coordinators[f"{ProxmoxType.Update}_{node}"] = coordinator_updates
 
             if config_entry.options.get(CONF_DISKS_ENABLE, True):
                 try:

--- a/custom_components/proxmoxve/__init__.py
+++ b/custom_components/proxmoxve/__init__.py
@@ -39,6 +39,7 @@ from .api import ProxmoxClient, get_api
 from .const import (
     CONF_CONTAINERS,
     CONF_DISKS_ENABLE,
+    CONF_UPDATE_ENABLE,
     CONF_LXC,
     CONF_NODE,
     CONF_NODES,

--- a/custom_components/proxmoxve/config_flow.py
+++ b/custom_components/proxmoxve/config_flow.py
@@ -398,20 +398,23 @@ class ProxmoxOptionsFlowHandler(config_entries.OptionsFlow):
                             entry_id=self.config_entry.entry_id,
                             device_identifier=identifier,
                         )
-             or not user_input.get(CONF_UPDATE_ENABLE):
+                        
+            if node not in (
+                node_selecition if node_selecition is not None else []
+            ) or not user_input.get(CONF_UPDATE_ENABLE):
                 coordinators = self.hass.data[DOMAIN][self.config_entry.entry_id][
                     COORDINATORS
                 ]
                 if f"{ProxmoxType.Update}_{node}" in coordinators:
-                    for coordinator_update in coordinators[f"{ProxmoxType.Update}_{node}"]:
-                        if (coordinator_data := coordinator_update.data) is None:
-                            continue
+                    coordinator_update = coordinators[f"{ProxmoxType.Update}_{node}"]
+                    if (coordinator_data := coordinator_update.data) is None:
+                        continue
 
-                        identifier = f"{self.config_entry.entry_id}_{ProxmoxType.Update.upper()}_{node}"
-                        await self.async_remove_device(
-                            entry_id=self.config_entry.entry_id,
-                            device_identifier=identifier,
-                        )
+                    identifier = f"{self.config_entry.entry_id}_{ProxmoxType.Update.upper()}_{node}"
+                    await self.async_remove_device(
+                        entry_id=self.config_entry.entry_id,
+                        device_identifier=identifier,
+                    )
 
         qemu_selecition = []
         if (

--- a/custom_components/proxmoxve/const.py
+++ b/custom_components/proxmoxve/const.py
@@ -12,6 +12,7 @@ CONF_NODES = "nodes"
 CONF_VMS = "vms"
 CONF_CONTAINERS = "containers"
 CONF_DISKS_ENABLE = "disks_enable"
+CONF_UPDATE_ENABLE = "update_enable"
 
 COORDINATORS = "coordinators"
 

--- a/custom_components/proxmoxve/strings.json
+++ b/custom_components/proxmoxve/strings.json
@@ -20,10 +20,12 @@
           "qemu": "Virtual Machines (QEMU)",
           "lxc": "Linux Containers (LXC)",
           "storage": "Storages",
-          "disks_enable": "Enable physical disk information"
+          "disks_enable": "Enable physical disk information",
+          "update_enable": "Enable update information"
         },
         "data_description": {
-          "disks_enable": "If you work with disk hibernation, you must disable this integration option so that it does not cause the disks to be reactivated unduly."
+          "disks_enable": "If you work with disk hibernation, you must disable this integration option so that it does not cause the disks to be reactivated unduly.",
+          "update_enable": "If you do not want to grant Sys.Modify permissions, disable update information fetching here to prevent permission errors."
         }
       },
       "reauth_confirm": {
@@ -128,10 +130,12 @@
           "qemu": "[%key:component::proxmoxve::config::step::expose::data::qemu%]",
           "lxc": "[%key:component::proxmoxve::config::step::expose::data::lxc%]",
           "storage": "[%key:component::proxmoxve::config::step::expose::data::storage%]",
-          "disks_enable": "[%key:component::proxmoxve::config::step::expose::data::disks_enable%]"
+          "disks_enable": "[%key:component::proxmoxve::config::step::expose::data::disks_enable%]",
+          "update_enable": "[%key:component::proxmoxve::config::step::expose::data::update_enable%]"
         },
         "data_description": {
-          "disks_enable": "[%key:component::proxmoxve::config::step::expose::data_description::disks_enable%]"
+          "disks_enable": "[%key:component::proxmoxve::config::step::expose::data_description::disks_enable%]",
+          "update_enable": "[%key:component::proxmoxve::config::step::expose::data_description::update_enable%]"
         }
       }
     },

--- a/custom_components/proxmoxve/translations/en.json
+++ b/custom_components/proxmoxve/translations/en.json
@@ -127,10 +127,12 @@
             "nodes": "Nodes",
             "qemu": "Virtual Machines (QEMU)",
             "storage": "Storages",
-            "disks_enable": "Enable physical disk information"
+            "disks_enable": "Enable physical disk information",
+            "update_enable": "Enable update information"
           },
           "data_description": {
-            "disks_enable": "If you work with disk hibernation, you must disable this integration option so that it does not cause the disks to be reactivated unduly."
+            "disks_enable": "If you work with disk hibernation, you must disable this integration option so that it does not cause the disks to be reactivated unduly.",
+            "update_enable": "If you do not want to grant Sys.Modify permissions, disable update information fetching here to prevent permission errors."
           }
         }
       },

--- a/custom_components/proxmoxve/translations/en.json
+++ b/custom_components/proxmoxve/translations/en.json
@@ -20,10 +20,12 @@
             "qemu": "Virtual Machines (QEMU)",
             "lxc": "Linux Containers (LXC)",
             "storage": "Storages",
-            "disks_enable": "Enable physical disk information"
+            "disks_enable": "Enable physical disk information",
+            "update_enable": "Enable update information"
           },
           "data_description": {
-            "disks_enable": "If you work with disk hibernation, you must disable this integration option so that it does not cause the disks to be reactivated unduly."
+            "disks_enable": "If you work with disk hibernation, you must disable this integration option so that it does not cause the disks to be reactivated unduly.",
+            "update_enable": "If you do not want to grant Sys.Modify permissions, disable update information fetching here to prevent permission errors."
           }
         },
         "reauth_confirm": {


### PR DESCRIPTION
Fixes #334

Proposal for an additional option to disable the update information coordinator. This would fix repair warnings for users not willing to give `Sys.Modify` permissions to the Proxmox user/group.

@dougiteixeira please review if this goes into the right direction from your point of view.

I tested this on my staging Home Assistant instance and it seems to work as expected.


### Open tasks
- [x] Translation EN
- [x] Testing
- [x] Docs / changelog