### PR TITLE
fix: storage id

### DIFF
--- a/custom_components/proxmoxve/__init__.py
+++ b/custom_components/proxmoxve/__init__.py
@@ -551,7 +551,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     for storage_id in config_entry.data[CONF_STORAGE]:
         if storage_id in [
-            (resource.get("id", None))
+            (resource.get("storage", None))
             for resource in (resources if resources is not None else [])
         ]:
             ir.async_delete_issue(

--- a/custom_components/proxmoxve/config_flow.py
+++ b/custom_components/proxmoxve/config_flow.py
@@ -252,7 +252,7 @@ class ProxmoxOptionsFlowHandler(config_entries.OptionsFlow):
                         resource_lxc[str(resource["vmid"])] = f"{resource['vmid']}"
                 if ("type" in resource) and (resource["type"] == ProxmoxType.Storage):
                     if "storage" in resource:
-                        resource_storage[str(resource["id"])] = resource["id"]
+                        resource_storage[str(resource["storage"])] = resource["storage"]
 
             return self.async_show_form(
                 step_id="change_expose",

--- a/custom_components/proxmoxve/coordinator.py
+++ b/custom_components/proxmoxve/coordinator.py
@@ -439,7 +439,7 @@ class ProxmoxStorageCoordinator(ProxmoxCoordinator):
         )
 
         for resource in resources if resources is not None else []:
-            if "storage" in resource and resource["id"] == self.resource_id:
+            if "storage" in resource and resource["storage"] == self.resource_id:
                 node_name = resource["node"]
 
         api_path = "cluster/resources?type=storage"
@@ -455,14 +455,14 @@ class ProxmoxStorageCoordinator(ProxmoxCoordinator):
 
         api_status = []
         for api_storage in api_storages:
-            if api_storage["id"] == self.resource_id:
+            if api_storage["storage"] == self.resource_id:
                 api_status = api_storage
 
         if api_status is None or "content" not in api_status:
             msg = f"Storage {self.resource_id} unable to be found"
             raise UpdateFailed(msg)
 
-        storage_id = api_status["id"]
+        storage_id = api_status["storage"]
         name = f"Storage {storage_id.replace("storage/", "")}"
         return ProxmoxStorageData(
             type=ProxmoxType.Storage,


### PR DESCRIPTION
My PVE version `8.2.0`

In my case, the PVE API returns storage IDs in prop named `storage` but not `id`. I think that's PVE made some breaking changes

But I found the prop name in this repo change from `storage` to `id` by PR #401 and issue #335

I think we need to gather some info and make both `storage` and `id` acceptable?