### PR TITLE
Add ZFS pool services and sensors

### DIFF
--- a/custom_components/proxmoxve/__init__.py
+++ b/custom_components/proxmoxve/__init__.py
@@ -43,7 +43,6 @@ from .api import ProxmoxClient, get_api
 from .const import (
     CONF_CONTAINERS,
     CONF_DISKS_ENABLE,
-    CONF_ZFS_ENABLE,
     CONF_LXC,
     CONF_NODE,
     CONF_NODES,
@@ -52,6 +51,7 @@ from .const import (
     CONF_STORAGE,
     CONF_TOKEN_NAME,
     CONF_VMS,
+    CONF_ZFS_ENABLE,
     COORDINATORS,
     DEFAULT_PORT,
     DEFAULT_REALM,
@@ -65,12 +65,12 @@ from .const import (
 )
 from .coordinator import (
     ProxmoxDiskCoordinator,
-    ProxmoxZFSCoordinator,
     ProxmoxLXCCoordinator,
     ProxmoxNodeCoordinator,
     ProxmoxQEMUCoordinator,
     ProxmoxStorageCoordinator,
     ProxmoxUpdateCoordinator,
+    ProxmoxZFSCoordinator,
 )
 
 if TYPE_CHECKING:
@@ -737,7 +737,7 @@ def device_info(
             serial_number = cordinator_resource.serial
 
     elif api_category is ProxmoxType.ZFS:
-        name = f"{api_category.capitalize()} {node}: {resource_id}"
+        name = f"{api_category.upper()} {node}: {resource_id}"
         identifier = (
             f"{config_entry.entry_id}_{api_category.upper()}_{node}_{resource_id}"
         )
@@ -746,7 +746,7 @@ def device_info(
             DOMAIN,
             f"{config_entry.entry_id}_{ProxmoxType.Node.upper()}_{node}",
         )
-        model = api_category.capitalize()
+        model = api_category.upper()
         manufacturer = None
         serial_number = None
 

--- a/custom_components/proxmoxve/__init__.py
+++ b/custom_components/proxmoxve/__init__.py
@@ -51,7 +51,6 @@ from .const import (
     CONF_STORAGE,
     CONF_TOKEN_NAME,
     CONF_VMS,
-    CONF_ZFS_ENABLE,
     COORDINATORS,
     DEFAULT_PORT,
     DEFAULT_REALM,
@@ -459,7 +458,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                     coordinators_disk.append(coordinator_disk)
                 coordinators[f"{ProxmoxType.Disk}_{node}"] = coordinators_disk
 
-            if config_entry.options.get(CONF_ZFS_ENABLE, True):
                 try:
                     pools = await hass.async_add_executor_job(
                         get_api, proxmox, f"nodes/{node}/disks/zfs"

--- a/custom_components/proxmoxve/__init__.py
+++ b/custom_components/proxmoxve/__init__.py
@@ -739,7 +739,7 @@ def device_info(
         identifier = (
             f"{config_entry.entry_id}_{api_category.upper()}_{node}_{resource_id}"
         )
-        url = f"https://{host}:{port}/#v1:0:=node/{node}::2::::::"
+        url = f"https://{host}:{port}/#v1:0:=node/{node}:4:=zfs::::::"
         via_device = (
             DOMAIN,
             f"{config_entry.entry_id}_{ProxmoxType.Node.upper()}_{node}",

--- a/custom_components/proxmoxve/config_flow.py
+++ b/custom_components/proxmoxve/config_flow.py
@@ -26,7 +26,6 @@ from .api import ProxmoxClient, get_api
 from .const import (
     CONF_CONTAINERS,
     CONF_DISKS_ENABLE,
-    CONF_ZFS_ENABLE,
     CONF_LXC,
     CONF_NODE,
     CONF_NODES,
@@ -35,6 +34,7 @@ from .const import (
     CONF_STORAGE,
     CONF_TOKEN_NAME,
     CONF_VMS,
+    CONF_ZFS_ENABLE,
     COORDINATORS,
     DEFAULT_PORT,
     DEFAULT_REALM,

--- a/custom_components/proxmoxve/config_flow.py
+++ b/custom_components/proxmoxve/config_flow.py
@@ -34,7 +34,6 @@ from .const import (
     CONF_STORAGE,
     CONF_TOKEN_NAME,
     CONF_VMS,
-    CONF_ZFS_ENABLE,
     COORDINATORS,
     DEFAULT_PORT,
     DEFAULT_REALM,
@@ -288,12 +287,6 @@ class ProxmoxOptionsFlowHandler(config_entries.OptionsFlow):
                                 CONF_DISKS_ENABLE, True
                             ),
                         ): selector.BooleanSelector(),
-                        vol.Optional(
-                            CONF_ZFS_ENABLE,
-                            default=self.config_entry.options.get(
-                                CONF_ZFS_ENABLE, True
-                            ),
-                        ): selector.BooleanSelector(),
                     }
                 ),
             )
@@ -313,10 +306,7 @@ class ProxmoxOptionsFlowHandler(config_entries.OptionsFlow):
             }
         )
 
-        options_data = {
-            CONF_DISKS_ENABLE: user_input.get(CONF_DISKS_ENABLE),
-            CONF_ZFS_ENABLE: user_input.get(CONF_ZFS_ENABLE),
-        }
+        options_data = {CONF_DISKS_ENABLE: user_input.get(CONF_DISKS_ENABLE)}
 
         self.hass.config_entries.async_update_entry(
             self.config_entry, data=config_data, options=options_data
@@ -389,11 +379,6 @@ class ProxmoxOptionsFlowHandler(config_entries.OptionsFlow):
                             entry_id=self.config_entry.entry_id,
                             device_identifier=identifier,
                         )
-
-            if node not in (
-                node_selecition if node_selecition is not None else []
-            ) or not user_input.get(CONF_ZFS_ENABLE):
-                coordinators = self.config_entry.runtime_data[COORDINATORS]
                 if f"{ProxmoxType.ZFS}_{node}" in coordinators:
                     for coordinator_zfs in coordinators[f"{ProxmoxType.ZFS}_{node}"]:
                         if (coordinator_data := coordinator_zfs.data) is None:
@@ -880,10 +865,6 @@ class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             CONF_DISKS_ENABLE,
                             default=True,
                         ): selector.BooleanSelector(),
-                        vol.Optional(
-                            CONF_ZFS_ENABLE,
-                            default=True,
-                        ): selector.BooleanSelector(),
                     }
                 ),
             )
@@ -927,10 +908,7 @@ class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(
             title=(f"{self._config[CONF_HOST]}:{self._config[CONF_PORT]}"),
             data=self._config,
-            options={
-                CONF_DISKS_ENABLE: user_input.get(CONF_DISKS_ENABLE),
-                CONF_ZFS_ENABLE: user_input.get(CONF_ZFS_ENABLE),
-            },
+            options={CONF_DISKS_ENABLE: user_input.get(CONF_DISKS_ENABLE)},
         )
 
     @staticmethod

--- a/custom_components/proxmoxve/const.py
+++ b/custom_components/proxmoxve/const.py
@@ -12,7 +12,6 @@ CONF_NODES = "nodes"
 CONF_VMS = "vms"
 CONF_CONTAINERS = "containers"
 CONF_DISKS_ENABLE = "disks_enable"
-CONF_ZFS_ENABLE = "zfs_enable"
 
 COORDINATORS = "coordinators"
 

--- a/custom_components/proxmoxve/const.py
+++ b/custom_components/proxmoxve/const.py
@@ -12,6 +12,7 @@ CONF_NODES = "nodes"
 CONF_VMS = "vms"
 CONF_CONTAINERS = "containers"
 CONF_DISKS_ENABLE = "disks_enable"
+CONF_ZFS_ENABLE = "zfs_enable"
 
 COORDINATORS = "coordinators"
 
@@ -48,6 +49,7 @@ class ProxmoxType(StrEnum):
     Update = "update"
     Disk = "disk"
     Resources = "resources"
+    ZFS = "zfs"
 
 
 class ProxmoxCommand(StrEnum):

--- a/custom_components/proxmoxve/coordinator.py
+++ b/custom_components/proxmoxve/coordinator.py
@@ -30,9 +30,9 @@ from .models import (
     ProxmoxLXCData,
     ProxmoxNodeData,
     ProxmoxStorageData,
-    ProxmoxZFSData,
     ProxmoxUpdateData,
     ProxmoxVMData,
+    ProxmoxZFSData,
 )
 
 if TYPE_CHECKING:

--- a/custom_components/proxmoxve/coordinator.py
+++ b/custom_components/proxmoxve/coordinator.py
@@ -30,6 +30,7 @@ from .models import (
     ProxmoxLXCData,
     ProxmoxNodeData,
     ProxmoxStorageData,
+    ProxmoxZFSData,
     ProxmoxUpdateData,
     ProxmoxVMData,
 )
@@ -175,47 +176,71 @@ class ProxmoxNodeCoordinator(ProxmoxCoordinator):
         if node_status != "":
             return ProxmoxNodeData(
                 type=ProxmoxType.Node,
-                model=api_status["cpuinfo"]["model"]
-                if (("cpuinfo" in api_status) and "model" in api_status["cpuinfo"])
-                else UNDEFINED,
+                model=(
+                    api_status["cpuinfo"]["model"]
+                    if (("cpuinfo" in api_status) and "model" in api_status["cpuinfo"])
+                    else UNDEFINED
+                ),
                 status=api_status.get("status", "Offline"),
-                version=api_status["version"].get("version", UNDEFINED)
-                if ("version" in api_status)
-                else UNDEFINED,
+                version=(
+                    api_status["version"].get("version", UNDEFINED)
+                    if ("version" in api_status)
+                    else UNDEFINED
+                ),
                 uptime=api_status.get("uptime", UNDEFINED),
                 cpu=api_status.get("cpu", UNDEFINED),
                 disk_total=api_status.get("disk_max", UNDEFINED),
                 disk_used=api_status.get("disk_used", UNDEFINED),
-                memory_total=api_status["memory"]["total"]
-                if (("memory" in api_status) and "total" in api_status["memory"])
-                else UNDEFINED,
-                memory_used=api_status["memory"]["used"]
-                if (("memory" in api_status) and "used" in api_status["memory"])
-                else UNDEFINED,
-                memory_free=api_status["memory"]["free"]
-                if (("memory" in api_status) and "free" in api_status["memory"])
-                else UNDEFINED,
-                swap_total=api_status["swap"]["total"]
-                if (("swap" in api_status) and "total" in api_status["swap"])
-                else UNDEFINED,
-                swap_free=api_status["swap"]["free"]
-                if (("swap" in api_status) and "free" in api_status["swap"])
-                else UNDEFINED,
-                swap_used=api_status["swap"]["used"]
-                if (("swap" in api_status) and "used" in api_status["swap"])
-                else UNDEFINED,
-                qemu_on=api_status["qemu"]["total"]
-                if (("qemu" in api_status) and "total" in api_status["qemu"])
-                else 0,
-                qemu_on_list=api_status["qemu"]["list"]
-                if (("qemu" in api_status) and "list" in api_status["qemu"])
-                else UNDEFINED,
-                lxc_on=api_status["lxc"]["total"]
-                if (("lxc" in api_status) and "total" in api_status["lxc"])
-                else 0,
-                lxc_on_list=api_status["lxc"]["list"]
-                if (("lxc" in api_status) and "list" in api_status["lxc"])
-                else UNDEFINED,
+                memory_total=(
+                    api_status["memory"]["total"]
+                    if (("memory" in api_status) and "total" in api_status["memory"])
+                    else UNDEFINED
+                ),
+                memory_used=(
+                    api_status["memory"]["used"]
+                    if (("memory" in api_status) and "used" in api_status["memory"])
+                    else UNDEFINED
+                ),
+                memory_free=(
+                    api_status["memory"]["free"]
+                    if (("memory" in api_status) and "free" in api_status["memory"])
+                    else UNDEFINED
+                ),
+                swap_total=(
+                    api_status["swap"]["total"]
+                    if (("swap" in api_status) and "total" in api_status["swap"])
+                    else UNDEFINED
+                ),
+                swap_free=(
+                    api_status["swap"]["free"]
+                    if (("swap" in api_status) and "free" in api_status["swap"])
+                    else UNDEFINED
+                ),
+                swap_used=(
+                    api_status["swap"]["used"]
+                    if (("swap" in api_status) and "used" in api_status["swap"])
+                    else UNDEFINED
+                ),
+                qemu_on=(
+                    api_status["qemu"]["total"]
+                    if (("qemu" in api_status) and "total" in api_status["qemu"])
+                    else 0
+                ),
+                qemu_on_list=(
+                    api_status["qemu"]["list"]
+                    if (("qemu" in api_status) and "list" in api_status["qemu"])
+                    else UNDEFINED
+                ),
+                lxc_on=(
+                    api_status["lxc"]["total"]
+                    if (("lxc" in api_status) and "total" in api_status["lxc"])
+                    else 0
+                ),
+                lxc_on_list=(
+                    api_status["lxc"]["list"]
+                    if (("lxc" in api_status) and "list" in api_status["lxc"])
+                    else UNDEFINED
+                ),
             )
         msg = f"Node {self.resource_id} unable to be found in host {self.config_entry.data[CONF_HOST]}"
         raise UpdateFailed(msg)
@@ -289,18 +314,22 @@ class ProxmoxQEMUCoordinator(ProxmoxCoordinator):
         return ProxmoxVMData(
             type=ProxmoxType.QEMU,
             node=node_name,
-            status=api_status["lock"]
-            if ("lock" in api_status and api_status["lock"] == "suspended")
-            else (api_status.get("status", UNDEFINED)),
+            status=(
+                api_status["lock"]
+                if ("lock" in api_status and api_status["lock"] == "suspended")
+                else (api_status.get("status", UNDEFINED))
+            ),
             name=api_status.get("name", UNDEFINED),
             health=api_status.get("qmpstatus", UNDEFINED),
             uptime=api_status.get("uptime", UNDEFINED),
             cpu=api_status.get("cpu", UNDEFINED),
             memory_total=api_status.get("maxmem", UNDEFINED),
             memory_used=api_status.get("mem", UNDEFINED),
-            memory_free=(api_status["maxmem"] - api_status["mem"])
-            if ("maxmem" in api_status and "mem" in api_status)
-            else UNDEFINED,
+            memory_free=(
+                (api_status["maxmem"] - api_status["mem"])
+                if ("maxmem" in api_status and "mem" in api_status)
+                else UNDEFINED
+            ),
             network_in=api_status.get("netin", UNDEFINED),
             network_out=api_status.get("netout", UNDEFINED),
             disk_total=api_status.get("maxdisk", UNDEFINED),
@@ -383,18 +412,22 @@ class ProxmoxLXCCoordinator(ProxmoxCoordinator):
             cpu=api_status.get("cpu", UNDEFINED),
             memory_total=api_status.get("maxmem", UNDEFINED),
             memory_used=api_status.get("mem", UNDEFINED),
-            memory_free=(api_status["maxmem"] - api_status["mem"])
-            if ("maxmem" in api_status and "mem" in api_status)
-            else UNDEFINED,
+            memory_free=(
+                (api_status["maxmem"] - api_status["mem"])
+                if ("maxmem" in api_status and "mem" in api_status)
+                else UNDEFINED
+            ),
             network_in=api_status.get("netin", UNDEFINED),
             network_out=api_status.get("netout", UNDEFINED),
             disk_total=api_status.get("maxdisk", UNDEFINED),
             disk_used=api_status.get("disk", UNDEFINED),
             swap_total=api_status.get("maxswap", UNDEFINED),
             swap_used=api_status.get("swap", UNDEFINED),
-            swap_free=(api_status["maxswap"] - api_status["swap"])
-            if ("maxswap" in api_status and "swap" in api_status)
-            else UNDEFINED,
+            swap_free=(
+                (api_status["maxswap"] - api_status["swap"])
+                if ("maxswap" in api_status and "swap" in api_status)
+                else UNDEFINED
+            ),
         )
 
 
@@ -471,6 +504,64 @@ class ProxmoxStorageCoordinator(ProxmoxCoordinator):
             disk_total=api_status.get("maxdisk", UNDEFINED),
             disk_used=api_status.get("disk", UNDEFINED),
             content=api_status.get("content", UNDEFINED),
+        )
+
+
+class ProxmoxZFSCoordinator(ProxmoxCoordinator):
+    """Proxmox VE ZFS data update coordinator."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        proxmox: ProxmoxAPI,
+        api_category: str,
+        node_name: str,
+        zfs_id: str,
+    ) -> None:
+        """Initialize the Proxmox ZFS coordinator."""
+        super().__init__(
+            hass,
+            LOGGER,
+            name=f"proxmox_coordinator_{api_category}_{zfs_id}",
+            update_interval=timedelta(seconds=UPDATE_INTERVAL),
+        )
+
+        self.hass = hass
+        self.config_entry: ConfigEntry = self.config_entry
+        self.proxmox = proxmox
+        self.node_name = node_name
+        self.resource_id = zfs_id
+
+    async def _async_update_data(self) -> ProxmoxStorageData:
+        """Update data for Proxmox Update."""
+        api_path = f"nodes/{self.node_name}/disks/zfs"
+        pools = await self.hass.async_add_executor_job(
+            poll_api,
+            self.hass,
+            self.config_entry,
+            self.proxmox,
+            api_path,
+            ProxmoxType.ZFS,
+            self.resource_id,
+        )
+
+        pool_status = []
+        for pool in pools:
+            if pool["name"] == self.resource_id:
+                pool_status = pool
+
+        if pool_status is None:
+            msg = f"ZFS Pool {self.resource_id} unable to be found for Node {self.node_name}"
+            raise UpdateFailed(msg)
+
+        return ProxmoxZFSData(
+            type=ProxmoxType.ZFS,
+            node=self.node_name,
+            name=f"ZFS Pool {self.resource_id}",
+            health=pool_status.get("health", UNDEFINED),
+            size=pool_status.get("size", UNDEFINED),
+            alloc=pool_status.get("alloc", UNDEFINED),
+            free=pool_status.get("free", UNDEFINED),
         )
 
 
@@ -723,21 +814,25 @@ class ProxmoxDiskCoordinator(ProxmoxCoordinator):
                     serial=disk.get("serial", None),
                     model=disk.get("model", None),
                     disk_type=disk_type,
-                    disk_wearout=float(disk["wearout"])
-                    if (
-                        "wearout" in disk
-                        and disk_type.upper() in ("SSD", "NVME")
-                        and str(disk["wearout"]).upper() != "N/A"
-                    )
-                    else UNDEFINED,
+                    disk_wearout=(
+                        float(disk["wearout"])
+                        if (
+                            "wearout" in disk
+                            and disk_type.upper() in ("SSD", "NVME")
+                            and str(disk["wearout"]).upper() != "N/A"
+                        )
+                        else UNDEFINED
+                    ),
                     size=float(disk["size"]) if "size" in disk else UNDEFINED,
                     health=disk.get("health", UNDEFINED),
-                    disk_rpm=float(disk["rpm"])
-                    if (
-                        "rpm" in disk
-                        and disk_type.upper() not in ("SSD", "NVME", "USB", None)
-                    )
-                    else UNDEFINED,
+                    disk_rpm=(
+                        float(disk["rpm"])
+                        if (
+                            "rpm" in disk
+                            and disk_type.upper() not in ("SSD", "NVME", "USB", None)
+                        )
+                        else UNDEFINED
+                    ),
                     temperature_air=disk_attributes.get("temperature_air", UNDEFINED),
                     temperature=disk_attributes.get("temperature", UNDEFINED),
                     power_cycles=disk_attributes.get("power_cycles", UNDEFINED),

--- a/custom_components/proxmoxve/diagnostics.py
+++ b/custom_components/proxmoxve/diagnostics.py
@@ -77,20 +77,20 @@ async def async_get_api_data_diagnostics(
             for qemu in qemu_node if qemu_node is not None else []:
                 nodes[node["node"]]["qemu"][qemu["vmid"]] = qemu
                 try:
-                    nodes[node["node"]]["qemu"][qemu["vmid"]][
-                        "backups"
-                    ] = await hass.async_add_executor_job(
-                        get_api,
-                        proxmox,
-                        f"nodes/{node['node']}/qemu/{qemu['vmid']}/snapshot",
+                    nodes[node["node"]]["qemu"][qemu["vmid"]]["backups"] = (
+                        await hass.async_add_executor_job(
+                            get_api,
+                            proxmox,
+                            f"nodes/{node['node']}/qemu/{qemu['vmid']}/snapshot",
+                        )
                     )
                 except ResourceException as error:
                     nodes[node["node"]]["qemu"][qemu["vmid"]]["backups"] = error
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["qemu"]["error"] = (
-                    "403 Forbidden: Permission check failed"
-                )
+                nodes[node["node"]]["qemu"][
+                    "error"
+                ] = "403 Forbidden: Permission check failed"
             else:
                 nodes[node["node"]]["qemu"]["error"] = error
 
@@ -102,20 +102,20 @@ async def async_get_api_data_diagnostics(
             for lxc in lxc_node if lxc_node is not None else []:
                 nodes[node["node"]]["lxc"][lxc["vmid"]] = lxc
                 try:
-                    nodes[node["node"]]["lxc"][lxc["vmid"]][
-                        "backups"
-                    ] = await hass.async_add_executor_job(
-                        get_api,
-                        proxmox,
-                        f"nodes/{node['node']}/lxc/{lxc['vmid']}/snapshot",
+                    nodes[node["node"]]["lxc"][lxc["vmid"]]["backups"] = (
+                        await hass.async_add_executor_job(
+                            get_api,
+                            proxmox,
+                            f"nodes/{node['node']}/lxc/{lxc['vmid']}/snapshot",
+                        )
                     )
                 except ResourceException as error:
                     nodes[node["node"]]["lxc"][lxc["vmid"]]["backups"]["error"] = error
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["lxc"]["error"] = (
-                    "403 Forbidden: Permission check failed"
-                )
+                nodes[node["node"]]["lxc"][
+                    "error"
+                ] = "403 Forbidden: Permission check failed"
             else:
                 nodes[node["node"]]["lxc"]["error"] = error
 
@@ -125,11 +125,23 @@ async def async_get_api_data_diagnostics(
             )
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["storage"]["error"] = (
-                    "403 Forbidden: Permission check failed"
-                )
+                nodes[node["node"]]["storage"][
+                    "error"
+                ] = "403 Forbidden: Permission check failed"
             else:
                 nodes[node["node"]]["storage"]["error"] = error
+
+        try:
+            nodes[node["node"]]["zfs"] = await hass.async_add_executor_job(
+                get_api, proxmox, f"nodes/{node['node']}/disks/zfs"
+            )
+        except ResourceException as error:
+            if error.status_code == 403:
+                nodes[node["node"]]["zfs"][
+                    "error"
+                ] = "403 Forbidden: Permission check failed"
+            else:
+                nodes[node["node"]]["zfs"]["error"] = error
 
         try:
             nodes[node["node"]]["updates"] = await hass.async_add_executor_job(
@@ -137,9 +149,9 @@ async def async_get_api_data_diagnostics(
             )
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["updates"]["error"] = (
-                    "403 Forbidden: Permission check failed"
-                )
+                nodes[node["node"]]["updates"][
+                    "error"
+                ] = "403 Forbidden: Permission check failed"
             else:
                 nodes[node["node"]]["updates"]["error"] = error
 
@@ -174,15 +186,15 @@ async def async_get_api_data_diagnostics(
 
             except ResourceException as error:
                 if error.status_code == 403:
-                    nodes[node["node"]]["disks"]["error"] = (
-                        "403 Forbidden: Permission check failed"
-                    )
+                    nodes[node["node"]]["disks"][
+                        "error"
+                    ] = "403 Forbidden: Permission check failed"
                 else:
                     nodes[node["node"]]["disks"]["error"] = error
         else:
-            nodes[node["node"]]["disks"]["info"] = (
-                "Disk information disabled in integration configuration options"
-            )
+            nodes[node["node"]]["disks"][
+                "info"
+            ] = "Disk information disabled in integration configuration options"
 
     return {
         "resources": resources,

--- a/custom_components/proxmoxve/diagnostics.py
+++ b/custom_components/proxmoxve/diagnostics.py
@@ -15,6 +15,7 @@ from .api import get_api
 from .const import CONF_DISKS_ENABLE, COORDINATORS, PROXMOX_CLIENT
 from .coordinator import (
     ProxmoxDiskCoordinator,
+    ProxmoxZFSCoordinator,
     ProxmoxLXCCoordinator,
     ProxmoxNodeCoordinator,
     ProxmoxQEMUCoordinator,
@@ -76,20 +77,20 @@ async def async_get_api_data_diagnostics(
             for qemu in qemu_node if qemu_node is not None else []:
                 nodes[node["node"]]["qemu"][qemu["vmid"]] = qemu
                 try:
-                    nodes[node["node"]]["qemu"][qemu["vmid"]][
-                        "backups"
-                    ] = await hass.async_add_executor_job(
-                        get_api,
-                        proxmox,
-                        f"nodes/{node['node']}/qemu/{qemu['vmid']}/snapshot",
+                    nodes[node["node"]]["qemu"][qemu["vmid"]]["backups"] = (
+                        await hass.async_add_executor_job(
+                            get_api,
+                            proxmox,
+                            f"nodes/{node['node']}/qemu/{qemu['vmid']}/snapshot",
+                        )
                     )
                 except ResourceException as error:
                     nodes[node["node"]]["qemu"][qemu["vmid"]]["backups"] = error
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["qemu"]["error"] = (
-                    "403 Forbidden: Permission check failed"
-                )
+                nodes[node["node"]]["qemu"][
+                    "error"
+                ] = "403 Forbidden: Permission check failed"
             else:
                 nodes[node["node"]]["qemu"]["error"] = error
 
@@ -101,20 +102,20 @@ async def async_get_api_data_diagnostics(
             for lxc in lxc_node if lxc_node is not None else []:
                 nodes[node["node"]]["lxc"][lxc["vmid"]] = lxc
                 try:
-                    nodes[node["node"]]["lxc"][lxc["vmid"]][
-                        "backups"
-                    ] = await hass.async_add_executor_job(
-                        get_api,
-                        proxmox,
-                        f"nodes/{node['node']}/lxc/{lxc['vmid']}/snapshot",
+                    nodes[node["node"]]["lxc"][lxc["vmid"]]["backups"] = (
+                        await hass.async_add_executor_job(
+                            get_api,
+                            proxmox,
+                            f"nodes/{node['node']}/lxc/{lxc['vmid']}/snapshot",
+                        )
                     )
                 except ResourceException as error:
                     nodes[node["node"]]["lxc"][lxc["vmid"]]["backups"]["error"] = error
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["lxc"]["error"] = (
-                    "403 Forbidden: Permission check failed"
-                )
+                nodes[node["node"]]["lxc"][
+                    "error"
+                ] = "403 Forbidden: Permission check failed"
             else:
                 nodes[node["node"]]["lxc"]["error"] = error
 
@@ -124,9 +125,9 @@ async def async_get_api_data_diagnostics(
             )
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["storage"]["error"] = (
-                    "403 Forbidden: Permission check failed"
-                )
+                nodes[node["node"]]["storage"][
+                    "error"
+                ] = "403 Forbidden: Permission check failed"
             else:
                 nodes[node["node"]]["storage"]["error"] = error
 
@@ -136,9 +137,9 @@ async def async_get_api_data_diagnostics(
             )
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["updates"]["error"] = (
-                    "403 Forbidden: Permission check failed"
-                )
+                nodes[node["node"]]["updates"][
+                    "error"
+                ] = "403 Forbidden: Permission check failed"
             else:
                 nodes[node["node"]]["updates"]["error"] = error
 
@@ -173,15 +174,15 @@ async def async_get_api_data_diagnostics(
 
             except ResourceException as error:
                 if error.status_code == 403:
-                    nodes[node["node"]]["disks"]["error"] = (
-                        "403 Forbidden: Permission check failed"
-                    )
+                    nodes[node["node"]]["disks"][
+                        "error"
+                    ] = "403 Forbidden: Permission check failed"
                 else:
                     nodes[node["node"]]["disks"]["error"] = error
         else:
-            nodes[node["node"]]["disks"]["info"] = (
-                "Disk information disabled in integration configuration options"
-            )
+            nodes[node["node"]]["disks"][
+                "info"
+            ] = "Disk information disabled in integration configuration options"
 
     return {
         "resources": resources,
@@ -200,7 +201,8 @@ async def async_get_config_entry_diagnostics(
         | ProxmoxLXCCoordinator
         | ProxmoxStorageCoordinator
         | ProxmoxUpdateCoordinator
-        | ProxmoxDiskCoordinator,
+        | ProxmoxDiskCoordinator
+        | ProxmoxZFSCoordinator,
     ] = config_entry.runtime_data[COORDINATORS]
 
     api_data = await async_get_api_data_diagnostics(hass, config_entry)
@@ -244,6 +246,7 @@ async def async_get_config_entry_diagnostics(
                 ProxmoxStorageCoordinator,
                 ProxmoxUpdateCoordinator,
                 ProxmoxDiskCoordinator,
+                ProxmoxZFSCoordinator,
             )
             and (coordinator_data := coordinator.data) is not None
         ):
@@ -259,6 +262,7 @@ async def async_get_config_entry_diagnostics(
                         ProxmoxStorageCoordinator,
                         ProxmoxUpdateCoordinator,
                         ProxmoxDiskCoordinator,
+                        ProxmoxZFSCoordinator,
                     )
                     and (coordinator_sub_data := coordinator_sub.data) is not None
                 ):
@@ -274,9 +278,9 @@ async def async_get_config_entry_diagnostics(
         "proxmox_coordinators": async_redact_data(
             proxmox_coordinators, TO_REDACT_COORD
         ),
-        "api_response": async_redact_data(api_data, TO_REDACT_API)
-        if api_data is not None
-        else {},
+        "api_response": (
+            async_redact_data(api_data, TO_REDACT_API) if api_data is not None else {}
+        ),
     }
 
 

--- a/custom_components/proxmoxve/diagnostics.py
+++ b/custom_components/proxmoxve/diagnostics.py
@@ -15,12 +15,12 @@ from .api import get_api
 from .const import CONF_DISKS_ENABLE, COORDINATORS, PROXMOX_CLIENT
 from .coordinator import (
     ProxmoxDiskCoordinator,
-    ProxmoxZFSCoordinator,
     ProxmoxLXCCoordinator,
     ProxmoxNodeCoordinator,
     ProxmoxQEMUCoordinator,
     ProxmoxStorageCoordinator,
     ProxmoxUpdateCoordinator,
+    ProxmoxZFSCoordinator,
 )
 
 if TYPE_CHECKING:
@@ -77,20 +77,20 @@ async def async_get_api_data_diagnostics(
             for qemu in qemu_node if qemu_node is not None else []:
                 nodes[node["node"]]["qemu"][qemu["vmid"]] = qemu
                 try:
-                    nodes[node["node"]]["qemu"][qemu["vmid"]]["backups"] = (
-                        await hass.async_add_executor_job(
-                            get_api,
-                            proxmox,
-                            f"nodes/{node['node']}/qemu/{qemu['vmid']}/snapshot",
-                        )
+                    nodes[node["node"]]["qemu"][qemu["vmid"]][
+                        "backups"
+                    ] = await hass.async_add_executor_job(
+                        get_api,
+                        proxmox,
+                        f"nodes/{node['node']}/qemu/{qemu['vmid']}/snapshot",
                     )
                 except ResourceException as error:
                     nodes[node["node"]]["qemu"][qemu["vmid"]]["backups"] = error
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["qemu"][
-                    "error"
-                ] = "403 Forbidden: Permission check failed"
+                nodes[node["node"]]["qemu"]["error"] = (
+                    "403 Forbidden: Permission check failed"
+                )
             else:
                 nodes[node["node"]]["qemu"]["error"] = error
 
@@ -102,20 +102,20 @@ async def async_get_api_data_diagnostics(
             for lxc in lxc_node if lxc_node is not None else []:
                 nodes[node["node"]]["lxc"][lxc["vmid"]] = lxc
                 try:
-                    nodes[node["node"]]["lxc"][lxc["vmid"]]["backups"] = (
-                        await hass.async_add_executor_job(
-                            get_api,
-                            proxmox,
-                            f"nodes/{node['node']}/lxc/{lxc['vmid']}/snapshot",
-                        )
+                    nodes[node["node"]]["lxc"][lxc["vmid"]][
+                        "backups"
+                    ] = await hass.async_add_executor_job(
+                        get_api,
+                        proxmox,
+                        f"nodes/{node['node']}/lxc/{lxc['vmid']}/snapshot",
                     )
                 except ResourceException as error:
                     nodes[node["node"]]["lxc"][lxc["vmid"]]["backups"]["error"] = error
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["lxc"][
-                    "error"
-                ] = "403 Forbidden: Permission check failed"
+                nodes[node["node"]]["lxc"]["error"] = (
+                    "403 Forbidden: Permission check failed"
+                )
             else:
                 nodes[node["node"]]["lxc"]["error"] = error
 
@@ -125,9 +125,9 @@ async def async_get_api_data_diagnostics(
             )
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["storage"][
-                    "error"
-                ] = "403 Forbidden: Permission check failed"
+                nodes[node["node"]]["storage"]["error"] = (
+                    "403 Forbidden: Permission check failed"
+                )
             else:
                 nodes[node["node"]]["storage"]["error"] = error
 
@@ -137,9 +137,9 @@ async def async_get_api_data_diagnostics(
             )
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["updates"][
-                    "error"
-                ] = "403 Forbidden: Permission check failed"
+                nodes[node["node"]]["updates"]["error"] = (
+                    "403 Forbidden: Permission check failed"
+                )
             else:
                 nodes[node["node"]]["updates"]["error"] = error
 
@@ -174,15 +174,15 @@ async def async_get_api_data_diagnostics(
 
             except ResourceException as error:
                 if error.status_code == 403:
-                    nodes[node["node"]]["disks"][
-                        "error"
-                    ] = "403 Forbidden: Permission check failed"
+                    nodes[node["node"]]["disks"]["error"] = (
+                        "403 Forbidden: Permission check failed"
+                    )
                 else:
                     nodes[node["node"]]["disks"]["error"] = error
         else:
-            nodes[node["node"]]["disks"][
-                "info"
-            ] = "Disk information disabled in integration configuration options"
+            nodes[node["node"]]["disks"]["info"] = (
+                "Disk information disabled in integration configuration options"
+            )
 
     return {
         "resources": resources,

--- a/custom_components/proxmoxve/models.py
+++ b/custom_components/proxmoxve/models.py
@@ -88,6 +88,19 @@ class ProxmoxStorageData:
 
 
 @dataclasses.dataclass
+class ProxmoxZFSData:
+    """Data parsed from the Proxmox API for ZFS."""
+
+    type: str
+    node: str
+    name: str
+    health: str | UndefinedType
+    size: float | UndefinedType
+    alloc: float | UndefinedType
+    free: float | UndefinedType
+
+
+@dataclasses.dataclass
 class ProxmoxUpdateData:
     """Data parsed from the Proxmox API for Updates."""
 

--- a/custom_components/proxmoxve/sensor.py
+++ b/custom_components/proxmoxve/sensor.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
     from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-    from .models import ProxmoxDiskData
+    from .models import ProxmoxDiskData, ProxmoxZFSData
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -131,6 +131,66 @@ PROXMOX_SENSOR_DISK: Final[tuple[ProxmoxSensorEntityDescription, ...]] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
         translation_key="disk_used_perc",
+    ),
+)
+PROXMOX_SENSOR_ZFS: Final[tuple[ProxmoxSensorEntityDescription, ...]] = (
+    ProxmoxSensorEntityDescription(
+        key="health",
+        name="Health",
+        icon="mdi:nas",
+        translation_key="zfs_health",
+    ),
+    ProxmoxSensorEntityDescription(
+        key="free_perc",
+        name="Pool free percentage",
+        icon="mdi:nas",
+        native_unit_of_measurement=PERCENTAGE,
+        conversion_fn=lambda x: (x * 100) if x != UNDEFINED and x > 0 else 0,
+        value_fn=lambda x: (
+            (x.free / x.size)
+            if (UNDEFINED not in (x.free, x.size) and x.size > 0)
+            else 0
+        ),
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        translation_key="zfs_free_perc",
+    ),
+    ProxmoxSensorEntityDescription(
+        key="size",
+        name="Pool total",
+        icon="mdi:nas",
+        native_unit_of_measurement=UnitOfInformation.BYTES,
+        device_class=SensorDeviceClass.DATA_SIZE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        suggested_unit_of_measurement=UnitOfInformation.GIGABYTES,
+        translation_key="zfs_total",
+    ),
+    ProxmoxSensorEntityDescription(
+        key="alloc",
+        name="Pool used",
+        icon="mdi:nas",
+        native_unit_of_measurement=UnitOfInformation.BYTES,
+        device_class=SensorDeviceClass.DATA_SIZE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        suggested_unit_of_measurement=UnitOfInformation.GIGABYTES,
+        translation_key="zfs_used",
+    ),
+    ProxmoxSensorEntityDescription(
+        key="used_perc",
+        name="Pool used percentage",
+        icon="mdi:nas",
+        native_unit_of_measurement=PERCENTAGE,
+        conversion_fn=lambda x: (x * 100) if x != UNDEFINED and x > 0 else 0,
+        value_fn=lambda x: (
+            (x.alloc / x.size)
+            if (UNDEFINED not in (x.alloc, x.size) and x.size > 0)
+            else 0
+        ),
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        translation_key="zfs_used_perc",
     ),
 )
 PROXMOX_SENSOR_MEMORY: Final[tuple[ProxmoxSensorEntityDescription, ...]] = (
@@ -632,8 +692,48 @@ async def async_setup_sensors_nodes(
                                 "new_unique_id": f"{config_entry.entry_id}_{node}_{coordinator_disks_data.path}_{description.key}",
                             }
                         )
+            await async_migrate_old_unique_ids(
+                hass, Platform.SENSOR, migrate_unique_id_disks
+            )
 
-    await async_migrate_old_unique_ids(hass, Platform.SENSOR, migrate_unique_id_disks)
+            coordinator_zfs_data: ProxmoxZFSData
+            for coordinator_zfs in coordinators.get(f"{ProxmoxType.ZFS}_{node}", []):
+                if (coordinator_zfs_data := coordinator_zfs.data) is None:
+                    continue
+
+                for description in PROXMOX_SENSOR_ZFS:
+                    if (
+                        (
+                            (
+                                data_value := getattr(
+                                    coordinator_zfs.data, description.key, False
+                                )
+                            )
+                            and data_value != UNDEFINED
+                        )
+                        or data_value == 0
+                        or (
+                            (value := description.value_fn) is not None
+                            and value(coordinator_zfs.data) is not None
+                        )
+                    ):
+                        sensors.append(
+                            create_sensor(
+                                coordinator=coordinator_zfs,
+                                info_device=device_info(
+                                    hass=hass,
+                                    config_entry=config_entry,
+                                    api_category=ProxmoxType.ZFS,
+                                    node=node,
+                                    resource_id=coordinator_zfs_data.name,
+                                    cordinator_resource=coordinator_zfs_data,
+                                ),
+                                description=description,
+                                resource_id=f"{node}_{coordinator_zfs_data.name}",
+                                config_entry=config_entry,
+                            )
+                        )
+
     return sensors
 
 

--- a/custom_components/proxmoxve/sensor.py
+++ b/custom_components/proxmoxve/sensor.py
@@ -133,66 +133,6 @@ PROXMOX_SENSOR_DISK: Final[tuple[ProxmoxSensorEntityDescription, ...]] = (
         translation_key="disk_used_perc",
     ),
 )
-PROXMOX_SENSOR_ZFS: Final[tuple[ProxmoxSensorEntityDescription, ...]] = (
-    ProxmoxSensorEntityDescription(
-        key="health",
-        name="Health",
-        icon="mdi:nas",
-        translation_key="zfs_health",
-    ),
-    ProxmoxSensorEntityDescription(
-        key="free_perc",
-        name="Pool free percentage",
-        icon="mdi:nas",
-        native_unit_of_measurement=PERCENTAGE,
-        conversion_fn=lambda x: (x * 100) if x != UNDEFINED and x > 0 else 0,
-        value_fn=lambda x: (
-            (x.free / x.size)
-            if (UNDEFINED not in (x.free, x.size) and x.size > 0)
-            else 0
-        ),
-        state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=1,
-        translation_key="zfs_free_perc",
-    ),
-    ProxmoxSensorEntityDescription(
-        key="size",
-        name="Pool total",
-        icon="mdi:nas",
-        native_unit_of_measurement=UnitOfInformation.BYTES,
-        device_class=SensorDeviceClass.DATA_SIZE,
-        state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=2,
-        suggested_unit_of_measurement=UnitOfInformation.GIGABYTES,
-        translation_key="zfs_total",
-    ),
-    ProxmoxSensorEntityDescription(
-        key="alloc",
-        name="Pool used",
-        icon="mdi:nas",
-        native_unit_of_measurement=UnitOfInformation.BYTES,
-        device_class=SensorDeviceClass.DATA_SIZE,
-        state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=2,
-        suggested_unit_of_measurement=UnitOfInformation.GIGABYTES,
-        translation_key="zfs_used",
-    ),
-    ProxmoxSensorEntityDescription(
-        key="used_perc",
-        name="Pool used percentage",
-        icon="mdi:nas",
-        native_unit_of_measurement=PERCENTAGE,
-        conversion_fn=lambda x: (x * 100) if x != UNDEFINED and x > 0 else 0,
-        value_fn=lambda x: (
-            (x.alloc / x.size)
-            if (UNDEFINED not in (x.alloc, x.size) and x.size > 0)
-            else 0
-        ),
-        state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=1,
-        translation_key="zfs_used_perc",
-    ),
-)
 PROXMOX_SENSOR_MEMORY: Final[tuple[ProxmoxSensorEntityDescription, ...]] = (
     ProxmoxSensorEntityDescription(
         key=ProxmoxKeyAPIParse.MEMORY_FREE,
@@ -561,6 +501,67 @@ PROXMOX_SENSOR_DISKS: Final[tuple[ProxmoxSensorEntityDescription, ...]] = (
     ),
 )
 
+PROXMOX_SENSOR_ZFS: Final[tuple[ProxmoxSensorEntityDescription, ...]] = (
+    ProxmoxSensorEntityDescription(
+        key="health",
+        name="Health",
+        icon="mdi:nas",
+        translation_key="zfs_health",
+    ),
+    ProxmoxSensorEntityDescription(
+        key="free_perc",
+        name="Free percentage",
+        icon="mdi:nas",
+        native_unit_of_measurement=PERCENTAGE,
+        conversion_fn=lambda x: (x * 100) if x != UNDEFINED and x > 0 else 0,
+        value_fn=lambda x: (
+            (x.free / x.size)
+            if (UNDEFINED not in (x.free, x.size) and x.size > 0)
+            else 0
+        ),
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        translation_key="zfs_free_perc",
+    ),
+    ProxmoxSensorEntityDescription(
+        key="size",
+        name="Size",
+        icon="mdi:nas",
+        native_unit_of_measurement=UnitOfInformation.BYTES,
+        device_class=SensorDeviceClass.DATA_SIZE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        suggested_unit_of_measurement=UnitOfInformation.GIGABYTES,
+        translation_key="zfs_total",
+    ),
+    ProxmoxSensorEntityDescription(
+        key="alloc",
+        name="Used",
+        icon="mdi:nas",
+        native_unit_of_measurement=UnitOfInformation.BYTES,
+        device_class=SensorDeviceClass.DATA_SIZE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        suggested_unit_of_measurement=UnitOfInformation.GIGABYTES,
+        translation_key="zfs_used",
+    ),
+    ProxmoxSensorEntityDescription(
+        key="used_perc",
+        name="Used percentage",
+        icon="mdi:nas",
+        native_unit_of_measurement=PERCENTAGE,
+        conversion_fn=lambda x: (x * 100) if x != UNDEFINED and x > 0 else 0,
+        value_fn=lambda x: (
+            (x.alloc / x.size)
+            if (UNDEFINED not in (x.alloc, x.size) and x.size > 0)
+            else 0
+        ),
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        translation_key="zfs_used_perc",
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -692,9 +693,6 @@ async def async_setup_sensors_nodes(
                                 "new_unique_id": f"{config_entry.entry_id}_{node}_{coordinator_disks_data.path}_{description.key}",
                             }
                         )
-            await async_migrate_old_unique_ids(
-                hass, Platform.SENSOR, migrate_unique_id_disks
-            )
 
             coordinator_zfs_data: ProxmoxZFSData
             for coordinator_zfs in coordinators.get(f"{ProxmoxType.ZFS}_{node}", []):
@@ -734,6 +732,9 @@ async def async_setup_sensors_nodes(
                             )
                         )
 
+            await async_migrate_old_unique_ids(
+                hass, Platform.SENSOR, migrate_unique_id_disks
+            )
     return sensors
 
 

--- a/custom_components/proxmoxve/translations/en.json
+++ b/custom_components/proxmoxve/translations/en.json
@@ -129,7 +129,8 @@
             "nodes": "Nodes",
             "qemu": "Virtual Machines (QEMU)",
             "storage": "Storages",
-            "disks_enable": "Enable physical disk information"
+            "disks_enable": "Enable physical disk information",
+            "zfs_enable": "Enable ZFS pool information"
           },
           "data_description": {
             "disks_enable": "If you work with disk hibernation, you must disable this integration option so that it does not cause the disks to be reactivated unduly."
@@ -198,7 +199,7 @@
         },
         "wakeonlan": {
           "name": "Wake-on-LAN"
-        }  
+        }
       },
       "sensor": {
         "cpu_used": {
@@ -230,6 +231,21 @@
         },
         "life_left": {
           "name": "Life left"
+        },
+        "zfs_health": {
+          "name": "Health"
+        },
+        "zfs_free_perc": {
+          "name": "Pool free percentage"
+        },
+        "zfs_total": {
+          "name": "Pool total"
+        },
+        "zfs_used": {
+          "name": "Pool used"
+        },
+        "zfs_used_perc": {
+          "name": "Pool used percentage"
         },
         "lxc_on": {
           "name": "Containers running",

--- a/custom_components/proxmoxve/translations/en.json
+++ b/custom_components/proxmoxve/translations/en.json
@@ -129,8 +129,7 @@
             "nodes": "Nodes",
             "qemu": "Virtual Machines (QEMU)",
             "storage": "Storages",
-            "disks_enable": "Enable physical disk information",
-            "zfs_enable": "Enable ZFS pool information"
+            "disks_enable": "Enable physical disk information"
           },
           "data_description": {
             "disks_enable": "If you work with disk hibernation, you must disable this integration option so that it does not cause the disks to be reactivated unduly."
@@ -236,16 +235,16 @@
           "name": "Health"
         },
         "zfs_free_perc": {
-          "name": "Pool free percentage"
+          "name": "Free percentage"
         },
         "zfs_total": {
-          "name": "Pool total"
+          "name": "Total"
         },
         "zfs_used": {
-          "name": "Pool used"
+          "name": "Used"
         },
         "zfs_used_perc": {
-          "name": "Pool used percentage"
+          "name": "Used percentage"
         },
         "lxc_on": {
           "name": "Containers running",


### PR DESCRIPTION
Added new services associated with nodes for ZFS pools per #469. Similar to disks, this commit adds an option to the config flow to enable/disable integrating ZFS pool data. If enabled, a new service is created for each ZFS pool associated with each enabled node. This data is pulled from the `GET /api2/json/nodes/{node}/disks/zfs` API.

Seems to work as expected but I'm new to this code base and may have missed something. One gap I am certain of is non-English translations. Let me know if there's any clean up or refactoring needed.

![image](https://github.com/user-attachments/assets/cb39e25d-d941-4190-b8c7-1715209beb4c)
![image](https://github.com/user-attachments/assets/82f1e9b2-18d6-43a7-8360-a8e2bcdad845)
