### PR TITLE
Fixes selection storages in option config flow

### DIFF
--- a/custom_components/proxmoxve/config_flow.py
+++ b/custom_components/proxmoxve/config_flow.py
@@ -189,7 +189,8 @@ class ProxmoxOptionsFlowHandler(config_entries.OptionsFlow):
 
             old_storage = []
             for storage in self.config_entry.data[CONF_STORAGE]:
-                # Prevents old selections (from when you used just the name instead of the id) from being loaded into the options config flow
+                # Prevents old selections (from when you used just the name instead of the id)
+                # from being loaded into the options config flow
                 if storage[:8] == "storage/":
                     old_storage.append(str(storage))
 

--- a/custom_components/proxmoxve/config_flow.py
+++ b/custom_components/proxmoxve/config_flow.py
@@ -189,7 +189,9 @@ class ProxmoxOptionsFlowHandler(config_entries.OptionsFlow):
 
             old_storage = []
             for storage in self.config_entry.data[CONF_STORAGE]:
-                old_storage.append(str(storage))
+                # Prevents old selections (from when you used just the name instead of the id) from being loaded into the options config flow
+                if storage[:8] == "storage/":
+                    old_storage.append(str(storage))
 
             host = self.config_entry.data[CONF_HOST]
             port = self.config_entry.data[CONF_PORT]


### PR DESCRIPTION
Prevents old selections (from when you used just the name instead of the id) from being loaded into the options config flow

Fixes #459 