### PR TITLE
Use `by_id_link` instead of `devpath` for unique id of entities and devices

### DIFF
--- a/custom_components/proxmoxve/__init__.py
+++ b/custom_components/proxmoxve/__init__.py
@@ -356,8 +356,8 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             except ResourceException:
                 continue
 
+            dev_reg = dr.async_get(hass)
             for disk in disks if disks is not None else []:
-                dev_reg = dr.async_get(hass)
                 device = dev_reg.async_get_or_create(
                     config_entry_id=config_entry.entry_id,
                     identifiers={
@@ -398,7 +398,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             config_entry,
             data=data_new,
             options={},
-            version=5,
+            version=6,
             minor_version=1,
         )
 

--- a/custom_components/proxmoxve/__init__.py
+++ b/custom_components/proxmoxve/__init__.py
@@ -445,6 +445,30 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
                 coordinators_disk = []
                 for disk in disks if disks is not None else []:
+                    dev_reg = dr.async_get(hass)
+                    device = dev_reg.async_get_or_create(
+                        config_entry_id=config_entry.entry_id,
+                        new_identifiers={
+                            (
+                                DOMAIN,
+                                (
+                                    f"{config_entry.entry_id}_{ProxmoxType.Disk.upper()}_{node}_{disk["path"]}"
+                                ),
+                            )
+                        },
+                    )
+                    dev_reg.async_update_device(
+                        device_id=device.id,
+                        new_identifiers={
+                            (
+                                DOMAIN,
+                                (
+                                    f"{config_entry.entry_id}_{ProxmoxType.Disk.upper()}_{node}_{disk["by_id_link"]}"
+                                ),
+                            )
+                        },
+                    )
+
                     coordinator_disk = ProxmoxDiskCoordinator(
                         hass=hass,
                         proxmox=proxmox,

--- a/custom_components/proxmoxve/__init__.py
+++ b/custom_components/proxmoxve/__init__.py
@@ -448,11 +448,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                     dev_reg = dr.async_get(hass)
                     device = dev_reg.async_get_or_create(
                         config_entry_id=config_entry.entry_id,
-                        new_identifiers={
+                        identifiers={
                             (
                                 DOMAIN,
                                 (
-                                    f"{config_entry.entry_id}_{ProxmoxType.Disk.upper()}_{node}_{disk["path"]}"
+                                    f"{config_entry.entry_id}_{ProxmoxType.Disk.upper()}_{node}_{disk["devpath"]}"
                                 ),
                             )
                         },

--- a/custom_components/proxmoxve/__init__.py
+++ b/custom_components/proxmoxve/__init__.py
@@ -450,7 +450,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                         proxmox=proxmox,
                         api_category=ProxmoxType.Disk,
                         node_name=node,
-                        disk_id=disk["devpath"],
+                        disk_id=disk["by_id_link"],
                     )
                     await coordinator_disk.async_refresh()
                     coordinators_disk.append(coordinator_disk)

--- a/custom_components/proxmoxve/__init__.py
+++ b/custom_components/proxmoxve/__init__.py
@@ -690,7 +690,7 @@ def device_info(
 
     elif api_category is ProxmoxType.Disk:
         model = cordinator_resource.model
-        name = f"{api_category.capitalize()} {node}: {model.replace('_', ' ')} ({resource_id})"
+        name = f"{api_category.capitalize()} {node}: {model.replace('_', ' ')}"
         identifier = (
             f"{config_entry.entry_id}_{api_category.upper()}_{node}_{resource_id}"
         )

--- a/custom_components/proxmoxve/binary_sensor.py
+++ b/custom_components/proxmoxve/binary_sensor.py
@@ -171,22 +171,6 @@ async def async_setup_binary_sensors_nodes(
 
                 for description in PROXMOX_BINARYSENSOR_DISKS:
                     if getattr(coordinator_disk.data, description.key, False):
-                        sensors.append(
-                            create_binary_sensor(
-                                coordinator=coordinator_disk,
-                                info_device=device_info(
-                                    hass=hass,
-                                    config_entry=config_entry,
-                                    api_category=ProxmoxType.Disk,
-                                    node=node,
-                                    resource_id=coordinator_data.path,
-                                    cordinator_resource=coordinator_data,
-                                ),
-                                description=description,
-                                resource_id=f"{node}_{coordinator_data.path}",
-                                config_entry=config_entry,
-                            )
-                        )
                         migrate_unique_id_disks.append(
                             {
                                 "old_unique_id": f"{config_entry.entry_id}_{coordinator_data.path}_{description.key}",
@@ -199,10 +183,26 @@ async def async_setup_binary_sensors_nodes(
                                 "new_unique_id": f"{config_entry.entry_id}_{node}_{coordinator_data.disk_id}_{description.key}",
                             }
                         )
+                        await async_migrate_old_unique_ids(
+                            hass, Platform.BINARY_SENSOR, migrate_unique_id_disks
+                        )
 
-    await async_migrate_old_unique_ids(
-        hass, Platform.BINARY_SENSOR, migrate_unique_id_disks
-    )
+                        sensors.append(
+                            create_binary_sensor(
+                                coordinator=coordinator_disk,
+                                info_device=device_info(
+                                    hass=hass,
+                                    config_entry=config_entry,
+                                    api_category=ProxmoxType.Disk,
+                                    node=node,
+                                    resource_id=coordinator_data.disk_id,
+                                    cordinator_resource=coordinator_data,
+                                ),
+                                description=description,
+                                resource_id=f"{node}_{coordinator_data.path}",
+                                config_entry=config_entry,
+                            )
+                        )
     return sensors
 
 

--- a/custom_components/proxmoxve/binary_sensor.py
+++ b/custom_components/proxmoxve/binary_sensor.py
@@ -190,7 +190,13 @@ async def async_setup_binary_sensors_nodes(
                         migrate_unique_id_disks.append(
                             {
                                 "old_unique_id": f"{config_entry.entry_id}_{coordinator_data.path}_{description.key}",
-                                "new_unique_id": f"{config_entry.entry_id}_{node}_{coordinator_data.path}_{description.key}",
+                                "new_unique_id": f"{config_entry.entry_id}_{node}_{coordinator_data.disk_id}_{description.key}",
+                            }
+                        )
+                        migrate_unique_id_disks.append(
+                            {
+                                "old_unique_id": f"{config_entry.entry_id}_{node}_{coordinator_data.path}_{description.key}",
+                                "new_unique_id": f"{config_entry.entry_id}_{node}_{coordinator_data.disk_id}_{description.key}",
                             }
                         )
 

--- a/custom_components/proxmoxve/binary_sensor.py
+++ b/custom_components/proxmoxve/binary_sensor.py
@@ -199,7 +199,7 @@ async def async_setup_binary_sensors_nodes(
                                     cordinator_resource=coordinator_data,
                                 ),
                                 description=description,
-                                resource_id=f"{node}_{coordinator_data.path}",
+                                resource_id=f"{node}_{coordinator_data.disk_id}",
                                 config_entry=config_entry,
                             )
                         )

--- a/custom_components/proxmoxve/config_flow.py
+++ b/custom_components/proxmoxve/config_flow.py
@@ -377,7 +377,7 @@ class ProxmoxOptionsFlowHandler(config_entries.OptionsFlow):
                         if (coordinator_data := coordinator_disk.data) is None:
                             continue
 
-                        identifier = f"{self.config_entry.entry_id}_{ProxmoxType.Disk.upper()}_{node}_{coordinator_data.path}"
+                        identifier = f"{self.config_entry.entry_id}_{ProxmoxType.Disk.upper()}_{node}_{coordinator_data.disk_id}"
                         await self.async_remove_device(
                             entry_id=self.config_entry.entry_id,
                             device_identifier=identifier,

--- a/custom_components/proxmoxve/config_flow.py
+++ b/custom_components/proxmoxve/config_flow.py
@@ -474,7 +474,7 @@ class ProxmoxOptionsFlowHandler(config_entries.OptionsFlow):
 class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """ProxmoxVE Config Flow class."""
 
-    VERSION = 5
+    VERSION = 6
     _reauth_entry: config_entries.ConfigEntry | None = None
 
     def __init__(self) -> None:

--- a/custom_components/proxmoxve/coordinator.py
+++ b/custom_components/proxmoxve/coordinator.py
@@ -175,47 +175,71 @@ class ProxmoxNodeCoordinator(ProxmoxCoordinator):
         if node_status != "":
             return ProxmoxNodeData(
                 type=ProxmoxType.Node,
-                model=api_status["cpuinfo"]["model"]
-                if (("cpuinfo" in api_status) and "model" in api_status["cpuinfo"])
-                else UNDEFINED,
+                model=(
+                    api_status["cpuinfo"]["model"]
+                    if (("cpuinfo" in api_status) and "model" in api_status["cpuinfo"])
+                    else UNDEFINED
+                ),
                 status=api_status.get("status", "Offline"),
-                version=api_status["version"].get("version", UNDEFINED)
-                if ("version" in api_status)
-                else UNDEFINED,
+                version=(
+                    api_status["version"].get("version", UNDEFINED)
+                    if ("version" in api_status)
+                    else UNDEFINED
+                ),
                 uptime=api_status.get("uptime", UNDEFINED),
                 cpu=api_status.get("cpu", UNDEFINED),
                 disk_total=api_status.get("disk_max", UNDEFINED),
                 disk_used=api_status.get("disk_used", UNDEFINED),
-                memory_total=api_status["memory"]["total"]
-                if (("memory" in api_status) and "total" in api_status["memory"])
-                else UNDEFINED,
-                memory_used=api_status["memory"]["used"]
-                if (("memory" in api_status) and "used" in api_status["memory"])
-                else UNDEFINED,
-                memory_free=api_status["memory"]["free"]
-                if (("memory" in api_status) and "free" in api_status["memory"])
-                else UNDEFINED,
-                swap_total=api_status["swap"]["total"]
-                if (("swap" in api_status) and "total" in api_status["swap"])
-                else UNDEFINED,
-                swap_free=api_status["swap"]["free"]
-                if (("swap" in api_status) and "free" in api_status["swap"])
-                else UNDEFINED,
-                swap_used=api_status["swap"]["used"]
-                if (("swap" in api_status) and "used" in api_status["swap"])
-                else UNDEFINED,
-                qemu_on=api_status["qemu"]["total"]
-                if (("qemu" in api_status) and "total" in api_status["qemu"])
-                else 0,
-                qemu_on_list=api_status["qemu"]["list"]
-                if (("qemu" in api_status) and "list" in api_status["qemu"])
-                else UNDEFINED,
-                lxc_on=api_status["lxc"]["total"]
-                if (("lxc" in api_status) and "total" in api_status["lxc"])
-                else 0,
-                lxc_on_list=api_status["lxc"]["list"]
-                if (("lxc" in api_status) and "list" in api_status["lxc"])
-                else UNDEFINED,
+                memory_total=(
+                    api_status["memory"]["total"]
+                    if (("memory" in api_status) and "total" in api_status["memory"])
+                    else UNDEFINED
+                ),
+                memory_used=(
+                    api_status["memory"]["used"]
+                    if (("memory" in api_status) and "used" in api_status["memory"])
+                    else UNDEFINED
+                ),
+                memory_free=(
+                    api_status["memory"]["free"]
+                    if (("memory" in api_status) and "free" in api_status["memory"])
+                    else UNDEFINED
+                ),
+                swap_total=(
+                    api_status["swap"]["total"]
+                    if (("swap" in api_status) and "total" in api_status["swap"])
+                    else UNDEFINED
+                ),
+                swap_free=(
+                    api_status["swap"]["free"]
+                    if (("swap" in api_status) and "free" in api_status["swap"])
+                    else UNDEFINED
+                ),
+                swap_used=(
+                    api_status["swap"]["used"]
+                    if (("swap" in api_status) and "used" in api_status["swap"])
+                    else UNDEFINED
+                ),
+                qemu_on=(
+                    api_status["qemu"]["total"]
+                    if (("qemu" in api_status) and "total" in api_status["qemu"])
+                    else 0
+                ),
+                qemu_on_list=(
+                    api_status["qemu"]["list"]
+                    if (("qemu" in api_status) and "list" in api_status["qemu"])
+                    else UNDEFINED
+                ),
+                lxc_on=(
+                    api_status["lxc"]["total"]
+                    if (("lxc" in api_status) and "total" in api_status["lxc"])
+                    else 0
+                ),
+                lxc_on_list=(
+                    api_status["lxc"]["list"]
+                    if (("lxc" in api_status) and "list" in api_status["lxc"])
+                    else UNDEFINED
+                ),
             )
         msg = f"Node {self.resource_id} unable to be found in host {self.config_entry.data[CONF_HOST]}"
         raise UpdateFailed(msg)
@@ -289,18 +313,22 @@ class ProxmoxQEMUCoordinator(ProxmoxCoordinator):
         return ProxmoxVMData(
             type=ProxmoxType.QEMU,
             node=node_name,
-            status=api_status["lock"]
-            if ("lock" in api_status and api_status["lock"] == "suspended")
-            else (api_status.get("status", UNDEFINED)),
+            status=(
+                api_status["lock"]
+                if ("lock" in api_status and api_status["lock"] == "suspended")
+                else (api_status.get("status", UNDEFINED))
+            ),
             name=api_status.get("name", UNDEFINED),
             health=api_status.get("qmpstatus", UNDEFINED),
             uptime=api_status.get("uptime", UNDEFINED),
             cpu=api_status.get("cpu", UNDEFINED),
             memory_total=api_status.get("maxmem", UNDEFINED),
             memory_used=api_status.get("mem", UNDEFINED),
-            memory_free=(api_status["maxmem"] - api_status["mem"])
-            if ("maxmem" in api_status and "mem" in api_status)
-            else UNDEFINED,
+            memory_free=(
+                (api_status["maxmem"] - api_status["mem"])
+                if ("maxmem" in api_status and "mem" in api_status)
+                else UNDEFINED
+            ),
             network_in=api_status.get("netin", UNDEFINED),
             network_out=api_status.get("netout", UNDEFINED),
             disk_total=api_status.get("maxdisk", UNDEFINED),
@@ -383,18 +411,22 @@ class ProxmoxLXCCoordinator(ProxmoxCoordinator):
             cpu=api_status.get("cpu", UNDEFINED),
             memory_total=api_status.get("maxmem", UNDEFINED),
             memory_used=api_status.get("mem", UNDEFINED),
-            memory_free=(api_status["maxmem"] - api_status["mem"])
-            if ("maxmem" in api_status and "mem" in api_status)
-            else UNDEFINED,
+            memory_free=(
+                (api_status["maxmem"] - api_status["mem"])
+                if ("maxmem" in api_status and "mem" in api_status)
+                else UNDEFINED
+            ),
             network_in=api_status.get("netin", UNDEFINED),
             network_out=api_status.get("netout", UNDEFINED),
             disk_total=api_status.get("maxdisk", UNDEFINED),
             disk_used=api_status.get("disk", UNDEFINED),
             swap_total=api_status.get("maxswap", UNDEFINED),
             swap_used=api_status.get("swap", UNDEFINED),
-            swap_free=(api_status["maxswap"] - api_status["swap"])
-            if ("maxswap" in api_status and "swap" in api_status)
-            else UNDEFINED,
+            swap_free=(
+                (api_status["maxswap"] - api_status["swap"])
+                if ("maxswap" in api_status and "swap" in api_status)
+                else UNDEFINED
+            ),
         )
 
 
@@ -604,7 +636,7 @@ class ProxmoxDiskCoordinator(ProxmoxCoordinator):
     async def _async_update_data(self) -> ProxmoxDiskData:
         """Update data  for Proxmox Disk."""
         if self.node_name is not None:
-            api_path = f"nodes/{self.node_name!s}/disks/list"
+            api_path = f"nodes/{self.node_name}/disks/list"
             api_status = await self.hass.async_add_executor_job(
                 poll_api,
                 self.hass,
@@ -622,7 +654,8 @@ class ProxmoxDiskCoordinator(ProxmoxCoordinator):
             return ProxmoxDiskData(
                 type=ProxmoxType.Disk,
                 node=self.node_name,
-                path=self.resource_id,
+                disk_id=self.resource_id,
+                path=None,
                 disk_wearout=UNDEFINED,
                 vendor=None,
                 serial=None,
@@ -640,9 +673,9 @@ class ProxmoxDiskCoordinator(ProxmoxCoordinator):
             )
 
         for disk in api_status:
-            if disk["devpath"] == self.resource_id:
+            if disk["by_id_link"] == self.resource_id:
                 disk_attributes = {}
-                api_path = f"nodes/{self.node_name}/disks/smart?disk={self.resource_id}"
+                api_path = f"nodes/{self.node_name}/disks/smart?disk={disk["devpath"]}"
                 try:
                     disk_attributes_api = await self.hass.async_add_executor_job(
                         poll_api,
@@ -718,26 +751,31 @@ class ProxmoxDiskCoordinator(ProxmoxCoordinator):
                 return ProxmoxDiskData(
                     type=ProxmoxType.Disk,
                     node=self.node_name,
-                    path=self.resource_id,
+                    disk_id=self.resource_id,
+                    path=disk["devpath"],
                     vendor=disk.get("vendor", None),
                     serial=disk.get("serial", None),
                     model=disk.get("model", None),
                     disk_type=disk_type,
-                    disk_wearout=float(disk["wearout"])
-                    if (
-                        "wearout" in disk
-                        and disk_type.upper() in ("SSD", "NVME")
-                        and str(disk["wearout"]).upper() != "N/A"
-                    )
-                    else UNDEFINED,
+                    disk_wearout=(
+                        float(disk["wearout"])
+                        if (
+                            "wearout" in disk
+                            and disk_type.upper() in ("SSD", "NVME")
+                            and str(disk["wearout"]).upper() != "N/A"
+                        )
+                        else UNDEFINED
+                    ),
                     size=float(disk["size"]) if "size" in disk else UNDEFINED,
                     health=disk.get("health", UNDEFINED),
-                    disk_rpm=float(disk["rpm"])
-                    if (
-                        "rpm" in disk
-                        and disk_type.upper() not in ("SSD", "NVME", "USB", None)
-                    )
-                    else UNDEFINED,
+                    disk_rpm=(
+                        float(disk["rpm"])
+                        if (
+                            "rpm" in disk
+                            and disk_type.upper() not in ("SSD", "NVME", "USB", None)
+                        )
+                        else UNDEFINED
+                    ),
                     temperature_air=disk_attributes.get("temperature_air", UNDEFINED),
                     temperature=disk_attributes.get("temperature", UNDEFINED),
                     power_cycles=disk_attributes.get("power_cycles", UNDEFINED),

--- a/custom_components/proxmoxve/diagnostics.py
+++ b/custom_components/proxmoxve/diagnostics.py
@@ -77,20 +77,20 @@ async def async_get_api_data_diagnostics(
             for qemu in qemu_node if qemu_node is not None else []:
                 nodes[node["node"]]["qemu"][qemu["vmid"]] = qemu
                 try:
-                    nodes[node["node"]]["qemu"][qemu["vmid"]]["backups"] = (
-                        await hass.async_add_executor_job(
-                            get_api,
-                            proxmox,
-                            f"nodes/{node['node']}/qemu/{qemu['vmid']}/snapshot",
-                        )
+                    nodes[node["node"]]["qemu"][qemu["vmid"]][
+                        "backups"
+                    ] = await hass.async_add_executor_job(
+                        get_api,
+                        proxmox,
+                        f"nodes/{node['node']}/qemu/{qemu['vmid']}/snapshot",
                     )
                 except ResourceException as error:
                     nodes[node["node"]]["qemu"][qemu["vmid"]]["backups"] = error
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["qemu"][
-                    "error"
-                ] = "403 Forbidden: Permission check failed"
+                nodes[node["node"]]["qemu"]["error"] = (
+                    "403 Forbidden: Permission check failed"
+                )
             else:
                 nodes[node["node"]]["qemu"]["error"] = error
 
@@ -102,20 +102,20 @@ async def async_get_api_data_diagnostics(
             for lxc in lxc_node if lxc_node is not None else []:
                 nodes[node["node"]]["lxc"][lxc["vmid"]] = lxc
                 try:
-                    nodes[node["node"]]["lxc"][lxc["vmid"]]["backups"] = (
-                        await hass.async_add_executor_job(
-                            get_api,
-                            proxmox,
-                            f"nodes/{node['node']}/lxc/{lxc['vmid']}/snapshot",
-                        )
+                    nodes[node["node"]]["lxc"][lxc["vmid"]][
+                        "backups"
+                    ] = await hass.async_add_executor_job(
+                        get_api,
+                        proxmox,
+                        f"nodes/{node['node']}/lxc/{lxc['vmid']}/snapshot",
                     )
                 except ResourceException as error:
                     nodes[node["node"]]["lxc"][lxc["vmid"]]["backups"]["error"] = error
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["lxc"][
-                    "error"
-                ] = "403 Forbidden: Permission check failed"
+                nodes[node["node"]]["lxc"]["error"] = (
+                    "403 Forbidden: Permission check failed"
+                )
             else:
                 nodes[node["node"]]["lxc"]["error"] = error
 
@@ -125,9 +125,9 @@ async def async_get_api_data_diagnostics(
             )
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["storage"][
-                    "error"
-                ] = "403 Forbidden: Permission check failed"
+                nodes[node["node"]]["storage"]["error"] = (
+                    "403 Forbidden: Permission check failed"
+                )
             else:
                 nodes[node["node"]]["storage"]["error"] = error
 
@@ -137,9 +137,9 @@ async def async_get_api_data_diagnostics(
             )
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["zfs"][
-                    "error"
-                ] = "403 Forbidden: Permission check failed"
+                nodes[node["node"]]["zfs"]["error"] = (
+                    "403 Forbidden: Permission check failed"
+                )
             else:
                 nodes[node["node"]]["zfs"]["error"] = error
 
@@ -149,9 +149,9 @@ async def async_get_api_data_diagnostics(
             )
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["updates"][
-                    "error"
-                ] = "403 Forbidden: Permission check failed"
+                nodes[node["node"]]["updates"]["error"] = (
+                    "403 Forbidden: Permission check failed"
+                )
             else:
                 nodes[node["node"]]["updates"]["error"] = error
 
@@ -186,15 +186,15 @@ async def async_get_api_data_diagnostics(
 
             except ResourceException as error:
                 if error.status_code == 403:
-                    nodes[node["node"]]["disks"][
-                        "error"
-                    ] = "403 Forbidden: Permission check failed"
+                    nodes[node["node"]]["disks"]["error"] = (
+                        "403 Forbidden: Permission check failed"
+                    )
                 else:
                     nodes[node["node"]]["disks"]["error"] = error
         else:
-            nodes[node["node"]]["disks"][
-                "info"
-            ] = "Disk information disabled in integration configuration options"
+            nodes[node["node"]]["disks"]["info"] = (
+                "Disk information disabled in integration configuration options"
+            )
 
     return {
         "resources": resources,

--- a/custom_components/proxmoxve/models.py
+++ b/custom_components/proxmoxve/models.py
@@ -104,6 +104,7 @@ class ProxmoxDiskData:
 
     type: str
     node: str
+    disk_id: str | None
     path: str
     serial: str | None
     model: str | None

--- a/custom_components/proxmoxve/sensor.py
+++ b/custom_components/proxmoxve/sensor.py
@@ -641,7 +641,7 @@ async def async_setup_sensors_nodes(
                                     cordinator_resource=coordinator_disks_data,
                                 ),
                                 description=description,
-                                resource_id=f"{node}_{coordinator_disks_data.path}",
+                                resource_id=f"{node}_{coordinator_disks_data.disk_id}",
                                 config_entry=config_entry,
                             )
                         )

--- a/custom_components/proxmoxve/sensor.py
+++ b/custom_components/proxmoxve/sensor.py
@@ -637,7 +637,7 @@ async def async_setup_sensors_nodes(
                                     config_entry=config_entry,
                                     api_category=ProxmoxType.Disk,
                                     node=node,
-                                    resource_id=coordinator_disks_data.path,
+                                    resource_id=coordinator_disks_data.disk_id,
                                     cordinator_resource=coordinator_disks_data,
                                 ),
                                 description=description,

--- a/custom_components/proxmoxve/sensor.py
+++ b/custom_components/proxmoxve/sensor.py
@@ -674,7 +674,6 @@ async def async_setup_sensors_nodes(
                             and value(coordinator_disk.data) is not None
                         )
                     ):
-
                         migrate_unique_id_disks.append(
                             {
                                 "old_unique_id": f"{config_entry.entry_id}_{coordinator_disks_data.path}_{description.key}",

--- a/custom_components/proxmoxve/sensor.py
+++ b/custom_components/proxmoxve/sensor.py
@@ -613,6 +613,22 @@ async def async_setup_sensors_nodes(
                             and value(coordinator_disk.data) is not None
                         )
                     ):
+
+                        migrate_unique_id_disks.append(
+                            {
+                                "old_unique_id": f"{config_entry.entry_id}_{coordinator_disks_data.path}_{description.key}",
+                                "new_unique_id": f"{config_entry.entry_id}_{node}_{coordinator_disks_data.disk_id}_{description.key}",
+                            }
+                        )
+                        migrate_unique_id_disks.append(
+                            {
+                                "old_unique_id": f"{config_entry.entry_id}_{node}_{coordinator_disks_data.path}_{description.key}",
+                                "new_unique_id": f"{config_entry.entry_id}_{node}_{coordinator_disks_data.disk_id}_{description.key}",
+                            }
+                        )
+                        await async_migrate_old_unique_ids(
+                            hass, Platform.SENSOR, migrate_unique_id_disks
+                        )
                         sensors.append(
                             create_sensor(
                                 coordinator=coordinator_disk,
@@ -629,14 +645,6 @@ async def async_setup_sensors_nodes(
                                 config_entry=config_entry,
                             )
                         )
-                        migrate_unique_id_disks.append(
-                            {
-                                "old_unique_id": f"{config_entry.entry_id}_{coordinator_disks_data.path}_{description.key}",
-                                "new_unique_id": f"{config_entry.entry_id}_{node}_{coordinator_disks_data.path}_{description.key}",
-                            }
-                        )
-
-    await async_migrate_old_unique_ids(hass, Platform.SENSOR, migrate_unique_id_disks)
     return sensors
 
 


### PR DESCRIPTION
Migrations have been implemented, the only side effect is that the entity ID will keep the reference to the `devpath`, you need to edit them manually or remove the device and reload the integration.

Fixes #481 