### PR TITLE
Handles missing `by_id_link` on some disks

### DIFF
--- a/custom_components/proxmoxve/__init__.py
+++ b/custom_components/proxmoxve/__init__.py
@@ -736,7 +736,6 @@ def device_info(
     proxmox_version = None
     manufacturer = None
     serial_number = None
-    via_device = None
     if api_category in (ProxmoxType.QEMU, ProxmoxType.LXC):
         coordinator = coordinators[f"{api_category}_{resource_id}"]
         if (coordinator_data := coordinator.data) is not None:
@@ -775,6 +774,7 @@ def device_info(
         name = f"{ProxmoxType.Node.capitalize()} {node}"
         identifier = f"{config_entry.entry_id}_{ProxmoxType.Node.upper()}_{node}"
         url = f"https://{host}:{port}/#v1:0:=node/{node}"
+        via_device = None
         model = model_processor
 
     elif api_category is ProxmoxType.Disk:

--- a/custom_components/proxmoxve/config_flow.py
+++ b/custom_components/proxmoxve/config_flow.py
@@ -742,7 +742,6 @@ class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle a flow initialized by a reconfig request."""
-
         self._reconfig_entry = self._get_reconfigure_entry()
         data = self._reconfig_entry.data
 

--- a/custom_components/proxmoxve/coordinator.py
+++ b/custom_components/proxmoxve/coordinator.py
@@ -696,50 +696,15 @@ class ProxmoxDiskCoordinator(ProxmoxCoordinator):
         """Update data  for Proxmox Disk."""
         if self.node_name is not None:
             api_path = f"nodes/{self.node_name}/disks/list"
-            api_status = [
-                {
-                    "by_id_link": "/dev/disk/by-id/nvme-nvme.144d-533237474e594148313039343533-53414d53554e47204d5a5650563235364844474c2d3030304831-00000001",
-                    "vendor": "unknown",
-                    "wearout": 57,
-                    "serial": "S27GNYAH109453",
-                    "osdid": -1,
-                    "gpt": 1,
-                    "used": "BIOS boot",
-                    "wwn": "nvme.144d-533237474e594148313039343533-53414d53554e47204d5a5650563235364844474c2d3030304831-00000001",
-                    "health": "PASSED",
-                    "osdid-list": None,
-                    "model": "SAMSUNG MZVPV256HDGL-000H1",
-                    "type": "nvme",
-                    "rpm": 0,
-                    "devpath": "/dev/nvme0n1",
-                    "size": 256060514304,
-                },
-                {
-                    "osdid": -1,
-                    "wearout": "N/A",
-                    "serial": "S6XDNS0T728613D",
-                    "vendor": "Samsung ",
-                    "gpt": 0,
-                    "health": "UNKNOWN",
-                    "osdid-list": None,
-                    "wwn": "unknown",
-                    "used": "ext4",
-                    "model": "PSSD_T7",
-                    "type": "ssd",
-                    "rpm": 0,
-                    "devpath": "/dev/sda",
-                    "size": 1000204886016,
-                },
-            ]
-            # api_status = await self.hass.async_add_executor_job(
-            #     poll_api,
-            #     self.hass,
-            #     self.config_entry,
-            #     self.proxmox,
-            #     api_path,
-            #     ProxmoxType.Disk,
-            #     self.resource_id,
-            # )
+            api_status = await self.hass.async_add_executor_job(
+                poll_api,
+                self.hass,
+                self.config_entry,
+                self.proxmox,
+                api_path,
+                ProxmoxType.Disk,
+                self.resource_id,
+            )
         else:
             msg = f"{self.resource_id} node not found"
             raise UpdateFailed(msg)

--- a/custom_components/proxmoxve/coordinator.py
+++ b/custom_components/proxmoxve/coordinator.py
@@ -696,15 +696,50 @@ class ProxmoxDiskCoordinator(ProxmoxCoordinator):
         """Update data  for Proxmox Disk."""
         if self.node_name is not None:
             api_path = f"nodes/{self.node_name}/disks/list"
-            api_status = await self.hass.async_add_executor_job(
-                poll_api,
-                self.hass,
-                self.config_entry,
-                self.proxmox,
-                api_path,
-                ProxmoxType.Disk,
-                self.resource_id,
-            )
+            api_status = [
+                {
+                    "by_id_link": "/dev/disk/by-id/nvme-nvme.144d-533237474e594148313039343533-53414d53554e47204d5a5650563235364844474c2d3030304831-00000001",
+                    "vendor": "unknown",
+                    "wearout": 57,
+                    "serial": "S27GNYAH109453",
+                    "osdid": -1,
+                    "gpt": 1,
+                    "used": "BIOS boot",
+                    "wwn": "nvme.144d-533237474e594148313039343533-53414d53554e47204d5a5650563235364844474c2d3030304831-00000001",
+                    "health": "PASSED",
+                    "osdid-list": None,
+                    "model": "SAMSUNG MZVPV256HDGL-000H1",
+                    "type": "nvme",
+                    "rpm": 0,
+                    "devpath": "/dev/nvme0n1",
+                    "size": 256060514304,
+                },
+                {
+                    "osdid": -1,
+                    "wearout": "N/A",
+                    "serial": "S6XDNS0T728613D",
+                    "vendor": "Samsung ",
+                    "gpt": 0,
+                    "health": "UNKNOWN",
+                    "osdid-list": None,
+                    "wwn": "unknown",
+                    "used": "ext4",
+                    "model": "PSSD_T7",
+                    "type": "ssd",
+                    "rpm": 0,
+                    "devpath": "/dev/sda",
+                    "size": 1000204886016,
+                },
+            ]
+            # api_status = await self.hass.async_add_executor_job(
+            #     poll_api,
+            #     self.hass,
+            #     self.config_entry,
+            #     self.proxmox,
+            #     api_path,
+            #     ProxmoxType.Disk,
+            #     self.resource_id,
+            # )
         else:
             msg = f"{self.resource_id} node not found"
             raise UpdateFailed(msg)
@@ -732,7 +767,9 @@ class ProxmoxDiskCoordinator(ProxmoxCoordinator):
             )
 
         for disk in api_status:
-            if disk["by_id_link"] == self.resource_id:
+            if ("by_id_link" in disk and disk["by_id_link"] == self.resource_id) or (
+                "serial" in disk and disk["serial"] == self.resource_id
+            ):
                 disk_attributes = {}
                 api_path = f"nodes/{self.node_name}/disks/smart?disk={disk["devpath"]}"
                 try:

--- a/custom_components/proxmoxve/diagnostics.py
+++ b/custom_components/proxmoxve/diagnostics.py
@@ -77,20 +77,20 @@ async def async_get_api_data_diagnostics(
             for qemu in qemu_node if qemu_node is not None else []:
                 nodes[node["node"]]["qemu"][qemu["vmid"]] = qemu
                 try:
-                    nodes[node["node"]]["qemu"][qemu["vmid"]]["backups"] = (
-                        await hass.async_add_executor_job(
-                            get_api,
-                            proxmox,
-                            f"nodes/{node['node']}/qemu/{qemu['vmid']}/snapshot",
-                        )
+                    nodes[node["node"]]["qemu"][qemu["vmid"]][
+                        "backups"
+                    ] = await hass.async_add_executor_job(
+                        get_api,
+                        proxmox,
+                        f"nodes/{node['node']}/qemu/{qemu['vmid']}/snapshot",
                     )
                 except ResourceException as error:
                     nodes[node["node"]]["qemu"][qemu["vmid"]]["backups"] = error
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["qemu"][
-                    "error"
-                ] = "403 Forbidden: Permission check failed"
+                nodes[node["node"]]["qemu"]["error"] = (
+                    "403 Forbidden: Permission check failed"
+                )
             else:
                 nodes[node["node"]]["qemu"]["error"] = error
 
@@ -102,20 +102,20 @@ async def async_get_api_data_diagnostics(
             for lxc in lxc_node if lxc_node is not None else []:
                 nodes[node["node"]]["lxc"][lxc["vmid"]] = lxc
                 try:
-                    nodes[node["node"]]["lxc"][lxc["vmid"]]["backups"] = (
-                        await hass.async_add_executor_job(
-                            get_api,
-                            proxmox,
-                            f"nodes/{node['node']}/lxc/{lxc['vmid']}/snapshot",
-                        )
+                    nodes[node["node"]]["lxc"][lxc["vmid"]][
+                        "backups"
+                    ] = await hass.async_add_executor_job(
+                        get_api,
+                        proxmox,
+                        f"nodes/{node['node']}/lxc/{lxc['vmid']}/snapshot",
                     )
                 except ResourceException as error:
                     nodes[node["node"]]["lxc"][lxc["vmid"]]["backups"]["error"] = error
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["lxc"][
-                    "error"
-                ] = "403 Forbidden: Permission check failed"
+                nodes[node["node"]]["lxc"]["error"] = (
+                    "403 Forbidden: Permission check failed"
+                )
             else:
                 nodes[node["node"]]["lxc"]["error"] = error
 
@@ -125,9 +125,9 @@ async def async_get_api_data_diagnostics(
             )
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["storage"][
-                    "error"
-                ] = "403 Forbidden: Permission check failed"
+                nodes[node["node"]]["storage"]["error"] = (
+                    "403 Forbidden: Permission check failed"
+                )
             else:
                 nodes[node["node"]]["storage"]["error"] = error
 
@@ -137,9 +137,9 @@ async def async_get_api_data_diagnostics(
             )
         except ResourceException as error:
             if error.status_code == 403:
-                nodes[node["node"]]["zfs"][
-                    "error"
-                ] = "403 Forbidden: Permission check failed"
+                nodes[node["node"]]["zfs"]["error"] = (
+                    "403 Forbidden: Permission check failed"
+                )
             else:
                 nodes[node["node"]]["zfs"]["error"] = error
 
@@ -150,9 +150,9 @@ async def async_get_api_data_diagnostics(
         except ResourceException as error:
             nodes[node["node"]]["updates"] = {}
             if error.status_code == 403:
-                nodes[node["node"]]["updates"][
-                    "error"
-                ] = "403 Forbidden: Permission check failed"
+                nodes[node["node"]]["updates"]["error"] = (
+                    "403 Forbidden: Permission check failed"
+                )
             else:
                 nodes[node["node"]]["updates"]["error"] = error
 
@@ -188,15 +188,15 @@ async def async_get_api_data_diagnostics(
 
             except ResourceException as error:
                 if error.status_code == 403:
-                    nodes[node["node"]]["disks"][
-                        "error"
-                    ] = "403 Forbidden: Permission check failed"
+                    nodes[node["node"]]["disks"]["error"] = (
+                        "403 Forbidden: Permission check failed"
+                    )
                 else:
                     nodes[node["node"]]["disks"]["error"] = error
         else:
-            nodes[node["node"]]["disks"][
-                "info"
-            ] = "Disk information disabled in integration configuration options"
+            nodes[node["node"]]["disks"]["info"] = (
+                "Disk information disabled in integration configuration options"
+            )
 
     return {
         "resources": resources,


### PR DESCRIPTION
In some instances, physical disks may not have a `by_id_link`, in which case the disk serial number will be used as the identifier.

If the disk does not have any of the keys, it will not be added to the integration.

The reason for not using `devpath` is that this may change with each host reboot (#481).

Fixes: #496 #497 #498 