### PR TITLE
Fix unique ID collision when multiple devices have a "wwn" value of  "unknown"

### DIFF
--- a/custom_components/proxmoxve/__init__.py
+++ b/custom_components/proxmoxve/__init__.py
@@ -591,7 +591,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                         node_name=node,
                         disk_id=(
                             disk["wwn"]
-                            if "wwn" in disk
+                            if "wwn" in disk and disk["wwn"] and disk["wwn"] != "unknown"
                             else (
                                 disk["by_id_link"]
                                 if "by_id_link" in disk


### PR DESCRIPTION
USB flash drives attached to Proxmox often have wwn values equal to the text string "unknown".  The code that sets the disk_id value uses wwn as its first option, so if two USB drives are attached to the Proxmox server, and they both have wwn = "unknown", they both get the same disk_id.  As a result only the first device is successfully loaded by the integration, while the second device triggers errors that "proxmoxve does not generate unique IDs. " 

Here is a sample of the error messages:  
`ERROR (MainThread) [homeassistant.components.sensor] Platform proxmoxve does not generate unique IDs. ID 01HWPE7JAQER11QR4SYYK4Z3ZY_pmxserver_unknown_size already exists - ignoring sensor.disk_pmxserver_usb_flash_disk_size`

The updated code adds a check to see if the wwn value is "unknown", in which case it forces the disk_id to be derived from one of the other options, i.e. either the "by_id_link" or "serial".   With this change, the USB flash drives in the test machine are now  assigned their serial numbers as their unique disk_id's, and are being loaded successfully into the integration