### PR TITLE
Fix translation placeholders that don't match en.json

### DIFF
--- a/custom_components/proxmoxve/translations/ca.json
+++ b/custom_components/proxmoxve/translations/ca.json
@@ -96,7 +96,7 @@
         },
         "import_node_not_exist": {
             "title": "El node {node} no existeix a {host}:{port}",
-            "description": "La configuració YAML de la instància {host}:{port} de {integration} ({platform}) ja existeix a la interfície d’usuari i s’ha ignorat en la importació.\n\nHas d’eliminar aquesta configuració del fitxer configuration.yaml i reiniciar Home Assistant."
+            "description": "El node {node} de la instància {host}:{port} de {integration} ({platform}) present a la configuració YAML no existeix en aquesta instància i s’ha ignorat en la importació.\n\nHas d’eliminar aquesta configuració del fitxer configuration.yaml i reiniciar Home Assistant."
         },
         "yaml_deprecated": {
             "title": "La configuració de {integration} en YAML està obsoleta",

--- a/custom_components/proxmoxve/translations/fr.json
+++ b/custom_components/proxmoxve/translations/fr.json
@@ -111,11 +111,11 @@
             "title": "L'utilisateur `{user}` n'a pas les permissions requises"
         },
         "resource_exception_forbiden": {
-            "description": "L'utilisateur `{user}` n'a pas les permissions suffisantes pour accéder à la ressource `{resource}`.\n\nAstuce sur les autorisations requises :\n* `{permission}`\n\nVeuillez vérifier la documentation et les autorisations d'utilisateur.",
+            "description": "L'utilisateur `{user}` n'a pas les permissions suffisantes pour accéder à la ressource `{resource}`.\n\nInformation sur les permissions requises :\n* `{permission}`\n\nVeuillez vérifier la documentation et les autorisations d'utilisateur.",
             "title": "Erreur d'autorisation pour `{resource}`"
         },
         "resource_command_forbiden": {
-            "description": "L'utilisateur `{user}` n'a pas les permissions suffisantes pour accéder à la ressource `{resource}`.\n\nAstuce sur les autorisations requises :\n* `{permission}`\n\nVeuillez vérifier la documentation et les autorisations d'utilisateur.",
+            "description": "L'utilisateur `{user}` n'a pas les permissions suffisantes pour exécuter la commande `{command}` sur la ressource `{resource}`.\n\nInformation sur les permissions requises :\n* `{permission}`\n\nVeuillez vérifier la documentation et les autorisations d'utilisateur.",
             "title": "Erreur de permission pour la commande sur `{resource}`"
         }
     },

--- a/custom_components/proxmoxve/translations/zh-CN.json
+++ b/custom_components/proxmoxve/translations/zh-CN.json
@@ -96,7 +96,7 @@
         },
         "import_node_not_exist": {
             "title": "节点 {node} 在 {host}:{port} 中不存在",
-            "description": "YAML 配置中指定的节点 {node} 在 {host}:{port} 实例中不存在，导入时已忽略。\n\n请从 `configuration.yaml` 中删除此配置并重启 Home Assistant。"
+            "description": "YAML 配置中指定的 {host}:{port} 实例（{integration}，`{platform}`）的节点 {node} 在该实例中不存在，导入时已忽略。\n\n请从 `configuration.yaml` 中删除此配置并重启 Home Assistant。"
         },
         "yaml_deprecated": {
             "title": "{integration} 的 YAML 配置方式已弃用",
@@ -116,7 +116,7 @@
         },
         "resource_command_forbiden": {
             "description": "用户 `{user}` 没有足够权限对资源 `{resource}` 执行命令 `{command}`。\n\n所需权限提示：\n* `{permission}`\n\n请检查文档中的权限要求并调整用户权限。",
-            "title": "执行 `{command}` 命令的权限错误"
+            "title": "对资源 `{resource}` 执行命令的权限错误"
         }
     },
     "options": {

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,57 @@
+"""Tests that localized strings stay consistent with the English reference."""
+
+import json
+import re
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+TRANSLATIONS_DIR = (
+    Path(__file__).parent.parent / "custom_components" / "proxmoxve" / "translations"
+)
+PLACEHOLDER = re.compile(r"{([a-zA-Z0-9_]+)}")
+
+
+def _flatten(data, prefix="") -> Iterator[tuple[str, str]]:
+    """Yield (dotted key, string value) for every string in a translation file."""
+    for key, value in data.items():
+        name = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            yield from _flatten(value, name)
+        elif isinstance(value, str):
+            yield name, value
+
+
+def _load(language) -> dict[str, str]:
+    """Load a translation file as a flat mapping."""
+    path = TRANSLATIONS_DIR / f"{language}.json"
+    return dict(_flatten(json.loads(path.read_text(encoding="utf-8"))))
+
+
+LANGUAGES = sorted(
+    path.stem for path in TRANSLATIONS_DIR.glob("*.json") if path.stem != "en"
+)
+
+
+@pytest.mark.parametrize("language", LANGUAGES)
+def test_placeholders_match_english(language):
+    """Home Assistant drops a localized string whose placeholders differ from en."""
+    english = _load("en")
+    mismatches = {
+        key: (
+            sorted(PLACEHOLDER.findall(value)),
+            sorted(PLACEHOLDER.findall(english[key])),
+        )
+        for key, value in _load(language).items()
+        if key in english
+        and set(PLACEHOLDER.findall(value)) != set(PLACEHOLDER.findall(english[key]))
+    }
+    assert not mismatches
+
+
+@pytest.mark.parametrize("language", LANGUAGES)
+def test_no_unknown_keys(language):
+    """A key absent from en.json is a typo: it can never be looked up."""
+    english = _load("en")
+    assert not [key for key in _load(language) if key not in english]


### PR DESCRIPTION
## Problem

Home Assistant validates that every localized string uses the same `{placeholders}` as its English reference and **discards the translation** (falling back to English) when they differ. Observed in the log:

```
Logger: homeassistant.helpers.translation
Source: helpers/translation.py:282
Validation of translation placeholders for localized (fr) string
component.proxmoxve.issues.resource_command_forbiden.description failed:
({'user', 'permission', 'resource'} != {'user', 'command', 'permission', 'resource'})
```

A scan of all translation files against `en.json` found three more latent mismatches that trigger the same warning for other locales.

## Changes

| File | Key | Problem |
|---|---|---|
| `fr.json` | `issues.resource_command_forbiden.description` | Verbatim copy of `resource_exception_forbiden.description` — never mentioned the command, missing `{command}` |
| `ca.json` | `issues.import_node_not_exist.description` | Verbatim copy of `import_already_configured.description` — wrong meaning, missing `{node}` |
| `zh-CN.json` | `issues.import_node_not_exist.description` | Dropped `{integration}` and `{platform}` |
| `zh-CN.json` | `issues.resource_command_forbiden.title` | Used `{command}`; the English title uses `{resource}` |

The `fr` "Astuce sur les autorisations requises" line is also reworded to "Information sur les permissions requises" in both `resource_*_forbiden` descriptions, so the two sibling strings stay consistent.

## Regression guard

`hassfest` does not check cross-language placeholder consistency for custom integrations, which is why this shipped. `tests/test_translations.py` asserts, per language, that every key shared with `en.json` uses the same placeholder set and that no key is absent from `en.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)